### PR TITLE
Copy of standard_coin.kinematics for nps_replay; up-to-date for all f…

### DIFF
--- a/DATfiles/standard_coin.kinematics
+++ b/DATfiles/standard_coin.kinematics
@@ -1,0 +1,35316 @@
+# NPS
+# 1h gtargmass_amu= 1.00794
+# 2d gtargmass_amu = 2.014
+# 12C gtargmass_amu= 12.0107
+# 27Al gtargmass_amu= 26.98
+# 
+
+0 - 99999
+nps_cal_ADCMode = 3
+nps_cal_arr_ADCMode = 3
+gpbeam = 10.540481931142118
+gtargmass_amu = -1
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+0 - 1138
+gpbeam = 10.386077023902068
+gtargmass_amu = 0.0
+htheta_lab = -29.99
+hpcentral = 3.0
+stheta_lab = 29.99
+nps_theta_offset=0
+#nps_pcentral = 2.6
+#ppartmass = 0.000511
+hpartmass = 0.000511
+
+1139 - 1142
+gpbeam = 10.539
+gtargmass_amu = 0.0
+htheta_lab = -36.2
+hpcentral = 4.367
+stheta_lab = 36.280
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1144 - 1152
+gpbeam = 10.539
+gtargmass_amu = 2.014
+htheta_lab = -36.2
+hpcentral = 4.367
+stheta_lab = 36.280
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1153 - 1165
+gpbeam = 10.539
+gtargmass_amu = 12.0107
+htheta_lab = -36.2
+hpcentral = 4.367
+stheta_lab = 36.280
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1166
+gpbeam = 10.539
+gtargmass_amu = 12.0107
+htheta_lab = -12.49
+hpcentral = 6.8
+stheta_lab = 37.1
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1167 - 1173
+gpbeam = 10.539
+gtargmass_amu = 2.014 
+htheta_lab = -12.49
+hpcentral = 6.8
+stheta_lab = 37.1
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1174 - 1187
+gpbeam = 10.539
+gtargmass_amu = 2.014 
+htheta_lab = -30.14
+hpcentral = 4.036
+stheta_lab = 33.19
+nps_theta_offset = -16.3
+hpartmass = 0.938272
+
+1188 - 1193
+gpbeam = 10.539
+gtargmass_amu = 12.0107 
+htheta_lab = -12.373
+hpcentral = 6.117
+stheta_lab = 37.
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1194 - 1237
+gpbeam = 10.539
+gtargmass_amu = 1.00794
+htheta_lab = -30.14
+hpcentral = 4.036
+stheta_lab = 30.9
+nps_theta_offset = -16.3
+hpartmass = 0.938272
+
+1238
+gpbeam = 10.539
+gtargmass_amu = 1.00794
+htheta_lab = -30.14
+hpcentral = 4.046
+stheta_lab = 32.05
+nps_theta_offset = -16.3
+hpartmass = 0.938272
+
+1239
+gpbeam = 10.539
+gtargmass_amu = 1.00794
+htheta_lab = -30.14
+hpcentral = 4.046
+stheta_lab = 33.19
+nps_theta_offset = -16.3
+hpartmass = 0.938272
+
+1240
+gpbeam = 10.539
+gtargmass_amu = 1.00794
+htheta_lab = -12.373
+hpcentral = 6.117
+stheta_lab = 37
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1241 - 1248
+gpbeam = 10.539
+gtargmass_amu= 12.0107
+htheta_lab = -12.395
+hpcentral = 6.117
+stheta_lab = 37.3
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1249
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -12.395
+hpcentral = 6.117
+stheta_lab = 37.3
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1250
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -19.26
+hpcentral = 6.117
+stheta_lab = 37.3
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1251 - 1252
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -20.700
+hpcentral = 6.117
+stheta_lab = 37.3
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1253
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -22.12
+hpcentral = 6.117
+stheta_lab = 37.3
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+
+1254 - 1259
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -22.12
+hpcentral = 6.117
+stheta_lab = 37.3
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1260
+gpbeam = 10.539
+gtargmass_amu= 12.0107
+htheta_lab = -15.33
+hpcentral = 5.639
+stheta_lab = 37.3
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1261 - 1265
+gpbeam = 10.539
+gtargmass_amu= 12.0107
+htheta_lab = -12.385
+hpcentral = 5.639
+stheta_lab = 37.3
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1266 
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -12.385
+hpcentral = 5.639
+stheta_lab = 37.3
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1267 
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -21.270
+hpcentral = 5.639
+stheta_lab = 37.3
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1268
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -22.7
+hpcentral = 5.639
+stheta_lab = 37.3
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1269
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -24.3
+hpcentral = 5.639
+stheta_lab = 37.3
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1270 - 1312
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -24.3
+hpcentral = 6.8
+stheta_lab = 36.88
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1313 - 1320
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 33.47
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1321 - 1322
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 33.47
+nps_theta_offset = -16.3
+hpartmass = 0.938272
+
+1323 - 1324
+gpbeam = 10.539
+gtargmass_amu= 26.98
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 33.47
+nps_theta_offset = -16.3
+hpartmass = 0.938272
+
+1325
+gpbeam = 10.539
+gtargmass_amu= 26.98
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 32.28
+nps_theta_offset = -16.3
+hpartmass = 0.938272
+
+1326 - 1327
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 32.28
+nps_theta_offset = -16.3
+hpartmass = 0.938272
+
+1328 - 1340
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 32.28
+nps_theta_offset = -16.3
+hpartmass = 0.938272
+
+1341 - 1343                                                                                                                       
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 33.48
+nps_theta_offset = -16.3
+hpartmass = 0.938272
+
+1344 - 1345
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 26.98                                                                                                            
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 33.48                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1349 - 1360 
+# DAQ test no beam
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 26.98                                                                                                            
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 33.48                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1361 - 1362 
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 31.29                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1363 - 1373
+# LED TEST, NPS ONLY
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 31.29                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1374 - 1395
+# Scaler and DAQ TEST
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 31.29                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1396 - 1412
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 31.29                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+
+1413 - 1414
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 31.19                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+
+1415 - 1416
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 32.28                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1417 - 1418
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 33.48                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1419
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 32.28                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1420 - 1421
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 31.19                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1422
+#BCM
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 31.19                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1423 - 1435
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 32.28                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1436 - 1437
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 31.19                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1438
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 32.28                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1439 - 1440
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 33.48                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1441
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 32.28                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1442 - 1442
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 31.19                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1443 - 1512
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 33.47                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1513 - 1517
+#LH2 boiling
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.89
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1518 - 1522
+#LD2 boiling
+gpbeam = 10.539
+gtargmass_amu= 2.014
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.89
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1523 - 1530
+#Carbon Boiling
+gpbeam = 10.539
+gtargmass_amu= 12.0107
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 36.89
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1531 - 1534
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -19.145
+hpcentral = 6.667
+stheta_lab = 36.880
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1535
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -17.995
+hpcentral = 6.667
+stheta_lab = 36.880
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1536
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -16.850
+hpcentral = 6.667
+stheta_lab = 36.880
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1537 - 1544
+gpbeam = 10.539
+gtargmass_amu= 12.0107
+htheta_lab = -12.490
+hpcentral = 6.667
+stheta_lab = 36.880
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1545
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -16.850
+hpcentral = 6.667
+stheta_lab = 36.880
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1546
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -18.005
+hpcentral = 6.667
+stheta_lab = 36.880
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1547 - 1548
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -19.150
+hpcentral = 6.667
+stheta_lab = 36.880
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1549 - 1550
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 32.28                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1551 - 1552
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 31.19                                                                                                               
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1553 - 1556
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 33.48                                                                                                               
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1557 - 1558
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 32.28                                                                                                                
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1559 - 1562
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 31.19                                                                                                               
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1563 - 1568
+gpbeam = 10.539                                                                                                                   
+gtargmass_amu= 1.00794                                                                                                             
+htheta_lab = -29.86                                                                                                               
+hpcentral = 4.0872                                                                                                                
+stheta_lab = 32.280                                                                                                               
+nps_theta_offset = -16.3                                                                                                          
+hpartmass = 0.938272
+
+1569 - 1571
+gpbeam = 10.539
+gtargmass_amu = 1.00794
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 32.280
+nps_theta_offset = -16.3
+hpartmass = 0.938272
+
+1572 - 1578
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1579
+gpbeam = 10.539
+gtargmass_amu= 26.98
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1580 - 1585
+gpbeam = 10.539
+gtargmass_amu= 2.014
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1586 - 1593
+gpbeam = 10.539
+gtargmass_amu= 1.00794
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1594 - 1634
+gpbeam = 10.539
+gtargmass_amu= 26.98
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset = -16.3
+hpartmass = 0.000511
+
+1635 - 1635
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1636 - 1636
+gpbeam = 10.539362366322305
+gtargmass_amu = 26.981539
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1637 - 1637
+gpbeam = 10.539006399527365
+gtargmass_amu = 26.981539
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1638 - 1638
+gpbeam = 10.539247123930027
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1639 - 1639
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1641 - 1641
+gpbeam = 10.53906783351516
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1642 - 1642
+gpbeam = 10.53893077276803
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1643 - 1643
+gpbeam = 10.539037561992437
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1644 - 1644
+gpbeam = 10.538871832371203
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1646 - 1646
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1647 - 1647
+gpbeam = 10.538940901576582
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1648 - 1648
+gpbeam = 10.53925031272593
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1649 - 1649
+gpbeam = 10.539236090236942
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1650 - 1650
+gpbeam = 10.53915057871181
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1651 - 1651
+gpbeam = 10.539203081665457
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1652 - 1652
+gpbeam = 10.5391890761108
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1653 - 1653
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1654 - 1654
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1655 - 1655
+gpbeam = 10.538863507459638
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1656 - 1656
+gpbeam = 10.538928106032127
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1657 - 1657
+gpbeam = 10.539208730683852
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1658 - 1658
+gpbeam = 10.538707797960154
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1659 - 1659
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1660 - 1660
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1661 - 1661
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1662 - 1662
+gpbeam = 10.538902807952853
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1663 - 1663
+gpbeam = 10.538809296939341
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1664 - 1664
+gpbeam = 10.538845754369014
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1665 - 1665
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1666 - 1666
+gpbeam = 10.538753577287238
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1667 - 1667
+gpbeam = 10.53863020242975
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1668 - 1668
+gpbeam = 10.53857024698297
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1669 - 1669
+gpbeam = 10.539257179355156
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1670 - 1670
+gpbeam = 10.538912800279135
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1671 - 1671
+gpbeam = 10.538984808526244
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1672 - 1672
+gpbeam = 10.539312102884029
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1673 - 1673
+gpbeam = 10.539058233853263
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1674 - 1674
+gpbeam = 10.538973589083911
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1675 - 1675
+gpbeam = 10.53909035638257
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1676 - 1676
+gpbeam = 10.538590194795178
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1677 - 1677
+gpbeam = 10.538487777677837
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1678 - 1678
+gpbeam = 10.538691941453376
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1679 - 1679
+gpbeam = 10.538735591514692
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1680 - 1680
+gpbeam = 10.538489292572887
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1681 - 1681
+gpbeam = 10.538791459026049
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1682 - 1682
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1683 - 1683
+gpbeam = 10.538524140567374
+gtargmass_amu = 26.981539
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1684 - 1684
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1685 - 1685
+gpbeam = 10.538493381113284
+gtargmass_amu = 26.981539
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1686 - 1686
+gpbeam = 10.538703932849405
+gtargmass_amu = 26.981539
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1687 - 1687
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1688 - 1688
+gpbeam = 10.538772801218736
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1689 - 1689
+gpbeam = 10.53869962869546
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1690 - 1690
+gpbeam = 10.53854188598754
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1691 - 1691
+gpbeam = 10.538736451137156
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1692 - 1692
+gpbeam = 10.538899234709364
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1693 - 1693
+gpbeam = 10.53876735668461
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1694 - 1694
+gpbeam = 10.538919196012706
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1695 - 1695
+gpbeam = 10.539074846944647
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1696 - 1696
+gpbeam = 10.538736004933018
+gtargmass_amu = 2.014101778
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1697 - 1697
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1698 - 1698
+gpbeam = 10.538516847037208
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1699 - 1699
+gpbeam = 10.538676662643736
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1700 - 1700
+gpbeam = 10.53846931298815
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1701 - 1701
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1702 - 1702
+gpbeam = 10.538659376731095
+gtargmass_amu = 0.0
+htheta_lab = -12.47
+hpcentral = 6.667
+stheta_lab = 36.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1703 - 1703
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -22.830000000000002
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1704 - 1704
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -22.830000000000002
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1705 - 1705
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -22.830000000000002
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1706 - 1706
+gpbeam = 10.538641123648336
+gtargmass_amu = 1.007825032
+htheta_lab = -22.84
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1707 - 1707
+gpbeam = 10.538403001600676
+gtargmass_amu = 1.007825032
+htheta_lab = -21.68
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1708 - 1708
+gpbeam = 10.53843377725915
+gtargmass_amu = 1.007825032
+htheta_lab = -20.54
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1709 - 1709
+gpbeam = 10.537384276735123
+gtargmass_amu = 12.0107
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1710 - 1710
+gpbeam = 10.538310108677285
+gtargmass_amu = 12.0107
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1711 - 1711
+gpbeam = 10.537611650192765
+gtargmass_amu = 12.0107
+htheta_lab = -16.500
+hpcentral = 5.878
+stheta_lab = 35.005
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1712 - 1712
+gpbeam = 10.540481931142118
+gtargmass_amu = 12.0107
+htheta_lab = -16.500
+hpcentral = 5.878
+stheta_lab = 35.005
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1713 - 1713
+gpbeam = 10.540481931142118
+gtargmass_amu = 12.0107
+htheta_lab = -16.500
+hpcentral = 5.878
+stheta_lab = 35.005
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1714 - 1714
+gpbeam = 10.538717579539613
+gtargmass_amu = 1.007825032
+htheta_lab = -22.835
+hpcentral = 5.878
+stheta_lab = 35.005
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1715 - 1715
+gpbeam = 10.53851679062114
+gtargmass_amu = 1.007825032
+htheta_lab = -21.685
+hpcentral = 5.878
+stheta_lab = 35.005
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1716 - 1716
+gpbeam = 10.538395524390518
+gtargmass_amu = 1.007825032
+htheta_lab = -20.545
+hpcentral = 5.878
+stheta_lab = 35.005
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1717 - 1717
+gpbeam = 10.538543034154232
+gtargmass_amu = 12.0107
+htheta_lab = -16.495
+hpcentral = 5.878
+stheta_lab = 35.005
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1718 - 1718
+gpbeam = 10.53857663627749
+gtargmass_amu = 12.0107
+htheta_lab = -16.495
+hpcentral = 5.878
+stheta_lab = 35.005
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1719 - 1719
+gpbeam = 10.538705023841318
+gtargmass_amu = 12.0107
+htheta_lab = -16.495
+hpcentral = 5.878
+stheta_lab = 35.005
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1720 - 1720
+gpbeam = 10.53830618901612
+gtargmass_amu = 12.0107
+htheta_lab = -16.495
+hpcentral = 5.878
+stheta_lab = 35.005
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1721 - 1721
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.005
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1722 - 1722
+gpbeam = 10.53847524878746
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.005
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1723 - 1723
+gpbeam = 10.538435536467935
+gtargmass_amu = 2.014101778
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1724 - 1724
+gpbeam = 10.538592445530448
+gtargmass_amu = 2.014101778
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1725 - 1725
+gpbeam = 10.538559970168183
+gtargmass_amu = 2.014101778
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1726 - 1726
+gpbeam = 10.538726366264193
+gtargmass_amu = 2.014101778
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1727 - 1727
+gpbeam = 10.538328762905635
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1728 - 1728
+gpbeam = 10.538505094536488
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1729 - 1729
+gpbeam = 10.538293540642165
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1730 - 1730
+gpbeam = 10.538481101273424
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1731 - 1731
+gpbeam = 10.538563472824901
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1732 - 1732
+gpbeam = 10.538524204889322
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1733 - 1733
+gpbeam = 10.538754564598957
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1734 - 1734
+gpbeam = 10.538529717883844
+gtargmass_amu = 26.981539
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1735 - 1735
+gpbeam = 10.539063889612317
+gtargmass_amu = 2.014101778
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1736 - 1736
+gpbeam = 10.53920333767562
+gtargmass_amu = 2.014101778
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1737 - 1737
+gpbeam = 10.539021694957896
+gtargmass_amu = 2.014101778
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1738 - 1738
+gpbeam = 10.539085842383928
+gtargmass_amu = 2.014101778
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1739 - 1739
+gpbeam = 10.539221094874314
+gtargmass_amu = 2.014101778
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1740 - 1740
+gpbeam = 10.539008525163174
+gtargmass_amu = 2.014101778
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1741 - 1741
+gpbeam = 10.538961573460922
+gtargmass_amu = 2.014101778
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1742 - 1742
+gpbeam = 10.538802808570813
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1743 - 1743
+gpbeam = 10.538832957590072
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1744 - 1744
+gpbeam = 10.538768687711766
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1745 - 1745
+gpbeam = 10.53884009447551
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1746 - 1746
+gpbeam = 10.538874383400216
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1747 - 1747
+gpbeam = 10.53895354123516
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1748 - 1748
+gpbeam = 10.538882581963076
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1749 - 1749
+gpbeam = 10.538911610460435
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1750 - 1750
+gpbeam = 10.538903959404617
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1751 - 1751
+gpbeam = 10.539133787212696
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1752 - 1752
+gpbeam = 10.53915050381391
+gtargmass_amu = 1.007825032
+htheta_lab = -12.49
+hpcentral = 6.667
+stheta_lab = 36.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1753 - 1753
+gpbeam = 10.539239000633694
+gtargmass_amu = 2.014101778
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1754 - 1754
+gpbeam = 10.539009671197407
+gtargmass_amu = 2.014101778
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1755 - 1755
+gpbeam = 10.538931515549287
+gtargmass_amu = 2.014101778
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1756 - 1756
+gpbeam = 10.538860508229158
+gtargmass_amu = 2.014101778
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1757 - 1757
+gpbeam = 10.539020456365732
+gtargmass_amu = 2.014101778
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1758 - 1758
+gpbeam = 10.538948720123305
+gtargmass_amu = 2.014101778
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1759 - 1759
+gpbeam = 10.539073029946389
+gtargmass_amu = 2.014101778
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1760 - 1760
+gpbeam = 10.538982680645445
+gtargmass_amu = 1.007825032
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1761 - 1761
+gpbeam = 10.538944900675215
+gtargmass_amu = 1.007825032
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1762 - 1762
+gpbeam = 10.538752093550661
+gtargmass_amu = 1.007825032
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1763 - 1763
+gpbeam = 10.538383625738835
+gtargmass_amu = 1.007825032
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1764 - 1764
+gpbeam = 10.538327565203515
+gtargmass_amu = 1.007825032
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1765 - 1765
+gpbeam = 10.538414127470517
+gtargmass_amu = 1.007825032
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1766 - 1766
+gpbeam = 10.538352375938395
+gtargmass_amu = 1.007825032
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1767 - 1767
+gpbeam = 10.537813044498257
+gtargmass_amu = 26.981539
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1768 - 1768
+gpbeam = 10.537580110393238
+gtargmass_amu = 2.014101778
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1769 - 1769
+gpbeam = 10.537824053208634
+gtargmass_amu = 2.014101778
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1770 - 1770
+gpbeam = 10.537819591631067
+gtargmass_amu = 2.014101778
+htheta_lab = -16.47
+hpcentral = 5.878
+stheta_lab = 35.04
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1772 - 1772
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -18.580000000000002
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1773 - 1773
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -18.580000000000002
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1774 - 1774
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.63
+hpcentral = 5.878
+stheta_lab = 34.86
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1776 - 1776
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1777 - 1777
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1778 - 1778
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1779 - 1779
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1780 - 1780
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1781 - 1781
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1782 - 1782
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1783 - 1783
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1784 - 1784
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1785 - 1785
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1786 - 1786
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1787 - 1787
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1788 - 1788
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1789 - 1789
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1790 - 1790
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1792 - 1792
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1793 - 1793
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1794 - 1794
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1795 - 1795
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1796 - 1796
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1797 - 1797
+gpbeam = 10.540481931142118
+gtargmass_amu = 12.0107
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1798 - 1798
+gpbeam = 10.540481931142118
+gtargmass_amu = 12.0107
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1799 - 1799
+gpbeam = 10.53830817297461
+gtargmass_amu = 12.0107
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1800 - 1800
+gpbeam = 10.538229036371295
+gtargmass_amu = 12.0107
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1801 - 1801
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1802 - 1802
+gpbeam = 10.53794651988037
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1803 - 1803
+gpbeam = 10.537898926812888
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1804 - 1804
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1805 - 1805
+gpbeam = 10.537916038303326
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1806 - 1806
+gpbeam = 10.537987701490557
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1807 - 1807
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1808 - 1808
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1809 - 1809
+gpbeam = 10.537867290206437
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1810 - 1810
+gpbeam = 10.538248302516784
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1811 - 1811
+gpbeam = 10.53783353134125
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1812 - 1812
+gpbeam = 10.537971598860052
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1813 - 1813
+gpbeam = 10.538654813019683
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1814 - 1814
+gpbeam = 10.538173693996551
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1815 - 1815
+gpbeam = 10.53842141449057
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1816 - 1816
+gpbeam = 10.538820590997345
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1817 - 1817
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1818 - 1818
+gpbeam = 10.53799097328885
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1819 - 1819
+gpbeam = 10.538155838509567
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1820 - 1820
+gpbeam = 10.538065280197895
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1821 - 1821
+gpbeam = 10.538107678348608
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1822 - 1822
+gpbeam = 10.537961009326136
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1823 - 1823
+gpbeam = 10.538473811486512
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1824 - 1824
+gpbeam = 10.538010699441324
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1825 - 1825
+gpbeam = 10.538572611486567
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1826 - 1826
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1827 - 1827
+gpbeam = 10.538272803160893
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1828 - 1828
+gpbeam = 10.538380708450878
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1829 - 1829
+gpbeam = 10.538213670036496
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1830 - 1830
+gpbeam = 10.53843101813539
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1831 - 1831
+gpbeam = 10.53846315236722
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1832 - 1832
+gpbeam = 10.53818699017606
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1833 - 1833
+gpbeam = 10.538561269682113
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1834 - 1834
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1835 - 1835
+gpbeam = 10.538257612176032
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1836 - 1836
+gpbeam = 10.538392290052665
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1837 - 1837
+gpbeam = 10.537143637424276
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1838 - 1838
+gpbeam = 10.538257189447872
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1839 - 1839
+gpbeam = 10.538208509013414
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1840 - 1840
+gpbeam = 10.538277054650486
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1841 - 1841
+gpbeam = 10.53824230224286
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1842 - 1842
+gpbeam = 10.538287481966295
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1843 - 1843
+gpbeam = 10.538308754454357
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1844 - 1844
+gpbeam = 10.538208224317975
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1845 - 1845
+gpbeam = 10.538190424478412
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1846 - 1846
+gpbeam = 10.538084690538613
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1847 - 1847
+gpbeam = 10.538230360532753
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1848 - 1848
+gpbeam = 10.538220425056007
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1849 - 1849
+gpbeam = 10.538269275783223
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1850 - 1850
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1851 - 1851
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1852 - 1852
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1853 - 1853
+gpbeam = 10.53825621879199
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1854 - 1854
+gpbeam = 10.538330946069834
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1855 - 1855
+gpbeam = 10.538287562499448
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1856 - 1856
+gpbeam = 10.53815040252431
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1857 - 1857
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1858 - 1858
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1859 - 1859
+gpbeam = 10.53857892544465
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1860 - 1860
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1861 - 1861
+gpbeam = 10.538295659220829
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1862 - 1862
+gpbeam = 10.538547132502107
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1863 - 1863
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1864 - 1864
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1865 - 1865
+gpbeam = 10.537227517818542
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1866 - 1866
+gpbeam = 10.538109105207575
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1867 - 1867
+gpbeam = 10.537966804021394
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1868 - 1868
+gpbeam = 10.53811192953444
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1869 - 1869
+gpbeam = 10.538174536973084
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1870 - 1870
+gpbeam = 10.538077494507345
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1871 - 1871
+gpbeam = 10.538209172524214
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1872 - 1872
+gpbeam = 10.538047740556573
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1873 - 1873
+gpbeam = 10.53813084675626
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1874 - 1874
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1875 - 1875
+gpbeam = 10.538011937918458
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1876 - 1876
+gpbeam = 10.537868906977584
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1877 - 1877
+gpbeam = 10.537508078968271
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1878 - 1878
+gpbeam = 10.537477083797594
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1879 - 1879
+gpbeam = 10.537542526334338
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1880 - 1880
+gpbeam = 10.537362249223618
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1881 - 1881
+gpbeam = 10.537367999137114
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1882 - 1882
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1883 - 1883
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1885 - 1885
+gpbeam = 10.538127476729823
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1886 - 1886
+gpbeam = 10.538023059654945
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1887 - 1887
+gpbeam = 10.538389725269713
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1888 - 1888
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1889 - 1889
+gpbeam = 10.538117703658768
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1890 - 1890
+gpbeam = 10.538042858047818
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1891 - 1891
+gpbeam = 10.538207706233873
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1892 - 1892
+gpbeam = 10.538303553764525
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1893 - 1893
+gpbeam = 10.538159738928929
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1894 - 1894
+gpbeam = 10.538238664915827
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1895 - 1895
+gpbeam = 10.538265414801165
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1896 - 1896
+gpbeam = 10.537893836648767
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1897 - 1897
+gpbeam = 10.537822320539695
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1898 - 1898
+gpbeam = 10.537760337539776
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1899 - 1899
+gpbeam = 10.537608313942695
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1900 - 1900
+gpbeam = 10.537469641179555
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1901 - 1901
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1902 - 1902
+gpbeam = 10.537377124503696
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1903 - 1903
+gpbeam = 10.537399754576597
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1904 - 1904
+gpbeam = 10.537565361986058
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1905 - 1905
+gpbeam = 10.537716733954408
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1906 - 1906
+gpbeam = 10.537638010222974
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1907 - 1907
+gpbeam = 10.537608751308303
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1908 - 1908
+gpbeam = 10.537484689555464
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1909 - 1909
+gpbeam = 10.537561296008045
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1910 - 1910
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1911 - 1911
+gpbeam = 10.537755710963468
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1912 - 1912
+gpbeam = 10.537251312868074
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1913 - 1913
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1914 - 1914
+gpbeam = 10.538004701091323
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1915 - 1915
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1916 - 1916
+gpbeam = 10.53730535083471
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1917 - 1917
+gpbeam = 10.53725741503586
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1918 - 1918
+gpbeam = 10.537596203178143
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1919 - 1919
+gpbeam = 10.537307796342573
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1920 - 1920
+gpbeam = 10.537570459512375
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1921 - 1921
+gpbeam = 10.537532851126715
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1922 - 1922
+gpbeam = 10.537945889996053
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1923 - 1923
+gpbeam = 10.53811004977426
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1924 - 1924
+gpbeam = 10.537759326635099
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1925 - 1925
+gpbeam = 10.53794832425643
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1926 - 1926
+gpbeam = 10.537716229802063
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1927 - 1927
+gpbeam = 10.537972669084931
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1928 - 1928
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1929 - 1929
+gpbeam = 10.537398752425222
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1930 - 1930
+gpbeam = 10.537153819638528
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1931 - 1931
+gpbeam = 10.537394599974569
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1932 - 1932
+gpbeam = 10.537591189792415
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1933 - 1933
+gpbeam = 10.537413917675995
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1934 - 1934
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1935 - 1935
+gpbeam = 10.537414295334576
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1936 - 1936
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1937 - 1937
+gpbeam = 10.537475016594568
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1938 - 1938
+gpbeam = 10.537635412160094
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1939 - 1939
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1940 - 1940
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1941 - 1941
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1942 - 1942
+gpbeam = 10.537208962638786
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1943 - 1943
+gpbeam = 10.53717029570913
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1944 - 1944
+gpbeam = 10.537107763670907
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1945 - 1945
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1946 - 1946
+gpbeam = 10.537154534671908
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1947 - 1947
+gpbeam = 10.53692726705316
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1948 - 1948
+gpbeam = 10.537217236028933
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1949 - 1949
+gpbeam = 10.537596227559375
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1950 - 1950
+gpbeam = 10.537309563183106
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1951 - 1951
+gpbeam = 10.53788256104384
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1952 - 1952
+gpbeam = 10.53740518473611
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1953 - 1953
+gpbeam = 10.536932385642396
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1954 - 1954
+gpbeam = 10.537409653507584
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1955 - 1955
+gpbeam = 10.537054294261301
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1956 - 1956
+gpbeam = 10.536746952989084
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1957 - 1957
+gpbeam = 10.536934168432905
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1958 - 1958
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1959 - 1959
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 35.02
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1960 - 1960
+gpbeam = 10.540481931142118
+gtargmass_amu = 12.0107
+htheta_lab = -12.385
+hpcentral = 6.117
+stheta_lab = 32.255
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1961 - 1961
+gpbeam = 10.538714741183279
+gtargmass_amu = 12.0107
+htheta_lab = -12.385
+hpcentral = 6.117
+stheta_lab = 32.255
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1962 - 1962
+gpbeam = 10.537929741480351
+gtargmass_amu = 12.0107
+htheta_lab = -12.385
+hpcentral = 6.117
+stheta_lab = 32.255
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1963 - 1963
+gpbeam = 10.538301124300501
+gtargmass_amu = 12.0107
+htheta_lab = -12.385
+hpcentral = 6.117
+stheta_lab = 32.255
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1964 - 1964
+gpbeam = 10.537193262999367
+gtargmass_amu = 12.0107
+htheta_lab = -12.385
+hpcentral = 6.117
+stheta_lab = 32.255
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1965 - 1965
+gpbeam = 10.538070004958845
+gtargmass_amu = 12.0107
+htheta_lab = -12.385
+hpcentral = 6.117
+stheta_lab = 32.255
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1966 - 1966
+gpbeam = 10.53834145007292
+gtargmass_amu = 12.0107
+htheta_lab = -12.385
+hpcentral = 6.117
+stheta_lab = 32.255
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1967 - 1967
+gpbeam = 10.540481931142118
+gtargmass_amu = 12.0107
+htheta_lab = -12.385
+hpcentral = 4.087
+stheta_lab = 32.255
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1968 - 1968
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 32.28
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1969 - 1969
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 32.28
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1970 - 1970
+gpbeam = 10.538352036824799
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 32.28
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1971 - 1971
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 32.28
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1972 - 1972
+gpbeam = 10.53851091302388
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 31.19
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1973 - 1973
+gpbeam = 10.53836559616384
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 33.480000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1974 - 1974
+gpbeam = 10.5383149900817
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 33.480000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1975 - 1975
+gpbeam = 10.538089192149966
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 33.480000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1976 - 1976
+gpbeam = 10.538146411068919
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 33.480000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1977 - 1977
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 32.28
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1978 - 1978
+gpbeam = 10.53851926848382
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 32.28
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1979 - 1979
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 32.28
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1980 - 1980
+gpbeam = 10.538236379432957
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 31.19
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1981 - 1981
+gpbeam = 10.538161757141545
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 31.19
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1982 - 1982
+gpbeam = 10.53824353938373
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.087
+stheta_lab = 31.19
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1983 - 1983
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1984 - 1984
+gpbeam = 10.53851973031934
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+1985 - 1985
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1986 - 1986
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1987 - 1987
+gpbeam = 10.53864484831106
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1988 - 1988
+gpbeam = 10.538902871433786
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1989 - 1989
+gpbeam = 10.538803754833092
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1990 - 1990
+gpbeam = 10.538827554431135
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1991 - 1991
+gpbeam = 10.538740703524542
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1992 - 1992
+gpbeam = 10.538914010022307
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1993 - 1993
+gpbeam = 10.539239740122929
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1994 - 1994
+gpbeam = 10.538789369166892
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1995 - 1995
+gpbeam = 10.538898908869806
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1996 - 1996
+gpbeam = 10.538844886969557
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1997 - 1997
+gpbeam = 10.538886028212023
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1998 - 1998
+gpbeam = 10.53888597688193
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+1999 - 1999
+gpbeam = 10.539048577829389
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2000 - 2000
+gpbeam = 10.538873271415202
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2001 - 2001
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2002 - 2002
+gpbeam = 10.538739988010308
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2003 - 2003
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2004 - 2004
+gpbeam = 10.539225708803794
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2005 - 2005
+gpbeam = 10.538458432104765
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2006 - 2006
+gpbeam = 10.538813172143694
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2007 - 2007
+gpbeam = 10.538390131265686
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2008 - 2008
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2009 - 2009
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2010 - 2010
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2011 - 2011
+gpbeam = 10.539082992877113
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2012 - 2012
+gpbeam = 10.538684664374792
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2013 - 2013
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2014 - 2014
+gpbeam = 10.538498835022667
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2015 - 2015
+gpbeam = 10.538793699831732
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2016 - 2016
+gpbeam = 10.538326198489653
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2017 - 2017
+gpbeam = 10.53821029971024
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2018 - 2018
+gpbeam = 10.538278849950158
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2019 - 2019
+gpbeam = 10.538399566756711
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2020 - 2020
+gpbeam = 10.538062687505516
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2021 - 2021
+gpbeam = 10.53801117676999
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2022 - 2022
+gpbeam = 10.538106965995594
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2023 - 2023
+gpbeam = 10.537811022325371
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2024 - 2024
+gpbeam = 10.537821184803718
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2025 - 2025
+gpbeam = 10.537962554884244
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2026 - 2026
+gpbeam = 10.53784924565297
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2027 - 2027
+gpbeam = 10.537999519876113
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2028 - 2028
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2029 - 2029
+gpbeam = 10.538389830844611
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2030 - 2030
+gpbeam = 10.537964347423987
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2031 - 2031
+gpbeam = 10.538195978100337
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2032 - 2032
+gpbeam = 10.538175265886867
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2033 - 2033
+gpbeam = 10.537887431057825
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2034 - 2034
+gpbeam = 10.53799692866102
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2035 - 2035
+gpbeam = 10.53789995397343
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2036 - 2036
+gpbeam = 10.537716424964927
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2037 - 2037
+gpbeam = 10.537707597518523
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2038 - 2038
+gpbeam = 10.537480198449568
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2039 - 2039
+gpbeam = 10.537474426723792
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2040 - 2040
+gpbeam = 10.537424678014718
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2041 - 2041
+gpbeam = 10.537390097070515
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2042 - 2042
+gpbeam = 10.537579147012341
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2043 - 2043
+gpbeam = 10.537234324324888
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2044 - 2044
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2045 - 2045
+gpbeam = 10.537321165398767
+gtargmass_amu = 26.981539
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2046 - 2046
+gpbeam = 10.537519130810814
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2047 - 2047
+gpbeam = 10.538003068368239
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2048 - 2048
+gpbeam = 10.537870353636892
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2049 - 2049
+gpbeam = 10.53776940549458
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2050 - 2050
+gpbeam = 10.53786277351427
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2051 - 2051
+gpbeam = 10.53768562745848
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2052 - 2052
+gpbeam = 10.537812570390374
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2053 - 2053
+gpbeam = 10.537769611173715
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2054 - 2054
+gpbeam = 10.537760011588366
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2055 - 2055
+gpbeam = 10.537802176878566
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2056 - 2056
+gpbeam = 10.537749602774285
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2057 - 2057
+gpbeam = 10.53787783472263
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2058 - 2058
+gpbeam = 10.537543831475578
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2059 - 2059
+gpbeam = 10.537834364819531
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2060 - 2060
+gpbeam = 10.537857407763877
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2061 - 2061
+gpbeam = 10.537817035332182
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2062 - 2062
+gpbeam = 10.538220391683774
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2063 - 2063
+gpbeam = 10.537928423653707
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2064 - 2064
+gpbeam = 10.537679900683102
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2065 - 2065
+gpbeam = 10.53763430815842
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2066 - 2066
+gpbeam = 10.537897777163145
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2067 - 2067
+gpbeam = 10.537916850317789
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2068 - 2068
+gpbeam = 10.537718916181548
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2069 - 2069
+gpbeam = 10.537937495014544
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2070 - 2070
+gpbeam = 10.537556673316613
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2071 - 2071
+gpbeam = 10.537665637343807
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2072 - 2072
+gpbeam = 10.53746172354198
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2073 - 2073
+gpbeam = 10.537722044317325
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2074 - 2074
+gpbeam = 10.53783137420926
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2075 - 2075
+gpbeam = 10.537624874765468
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2076 - 2076
+gpbeam = 10.537596281408986
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2077 - 2077
+gpbeam = 10.537476329577968
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2078 - 2078
+gpbeam = 10.537586041814041
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2079 - 2079
+gpbeam = 10.53748210694001
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2080 - 2080
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2081 - 2081
+gpbeam = 10.537448635999473
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2082 - 2082
+gpbeam = 10.53761579844854
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2083 - 2083
+gpbeam = 10.537506291871365
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2084 - 2084
+gpbeam = 10.53761146345446
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2085 - 2085
+gpbeam = 10.537867272194354
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2086 - 2086
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2087 - 2087
+gpbeam = 10.537407512953182
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2088 - 2088
+gpbeam = 10.538092049537218
+gtargmass_amu = 26.981539
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2089 - 2089
+gpbeam = 10.537423355014182
+gtargmass_amu = 26.981539
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2090 - 2090
+gpbeam = 10.537682899376987
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2091 - 2091
+gpbeam = 10.538043158110865
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2092 - 2092
+gpbeam = 10.537844592056999
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2093 - 2093
+gpbeam = 10.53792525276722
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2094 - 2094
+gpbeam = 10.537754559809754
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2095 - 2095
+gpbeam = 10.53785052041978
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2096 - 2096
+gpbeam = 10.537664801420505
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2097 - 2097
+gpbeam = 10.53766863425068
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2098 - 2098
+gpbeam = 10.537694759664591
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2099 - 2099
+gpbeam = 10.537849339688108
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2100 - 2100
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2101 - 2101
+gpbeam = 10.537427514528792
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2102 - 2102
+gpbeam = 10.537786759115749
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2103 - 2103
+gpbeam = 10.53751185126695
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2104 - 2104
+gpbeam = 10.537655195488187
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2105 - 2105
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2106 - 2106
+gpbeam = 10.537681580885039
+gtargmass_amu = 26.981539
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2107 - 2107
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2108 - 2108
+gpbeam = 10.537979871680523
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2109 - 2109
+gpbeam = 10.537276297722743
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2110 - 2110
+gpbeam = 10.537351457641662
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2111 - 2111
+gpbeam = 10.538070324772272
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2112 - 2112
+gpbeam = 10.53724915040231
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2113 - 2113
+gpbeam = 10.537628293671016
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2114 - 2114
+gpbeam = 10.537696170886901
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2115 - 2115
+gpbeam = 10.53782993832072
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2116 - 2116
+gpbeam = 10.537644746092369
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2117 - 2117
+gpbeam = 10.537870730668164
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2118 - 2118
+gpbeam = 10.537662141942885
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2119 - 2119
+gpbeam = 10.537689977781092
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2120 - 2120
+gpbeam = 10.537836651096047
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2121 - 2121
+gpbeam = 10.537851281498883
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2122 - 2122
+gpbeam = 10.537808099583254
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2123 - 2123
+gpbeam = 10.537703230573605
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2124 - 2124
+gpbeam = 10.537557528252902
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2125 - 2125
+gpbeam = 10.537333159323934
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2126 - 2126
+gpbeam = 10.537483639546299
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2127 - 2127
+gpbeam = 10.537422519636278
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2128 - 2128
+gpbeam = 10.537466170862313
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2129 - 2129
+gpbeam = 10.537350761108105
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2130 - 2130
+gpbeam = 10.537121149672481
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2131 - 2131
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2132 - 2132
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2133 - 2133
+gpbeam = 10.537525204716825
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2134 - 2134
+gpbeam = 10.537083749830305
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2135 - 2135
+gpbeam = 10.537080618101795
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2136 - 2136
+gpbeam = 10.538920620825909
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2137 - 2137
+gpbeam = 10.537027065695856
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2138 - 2138
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2139 - 2139
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2140 - 2140
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2141 - 2141
+gpbeam = 10.537010769322151
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2142 - 2142
+gpbeam = 10.537236211601789
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2143 - 2143
+gpbeam = 10.536619821451396
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2144 - 2144
+gpbeam = 10.536426624441205
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2145 - 2145
+gpbeam = 10.537061702432831
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2146 - 2146
+gpbeam = 10.536784390107915
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2147 - 2147
+gpbeam = 10.537130000038779
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2148 - 2148
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2149 - 2149
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2150 - 2150
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2151 - 2151
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2152 - 2152
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2153 - 2153
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2154 - 2154
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2155 - 2155
+gpbeam = 10.536417741486545
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2156 - 2156
+gpbeam = 10.536439334581301
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2157 - 2157
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2158 - 2158
+gpbeam = 10.537547124651796
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2159 - 2159
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2160 - 2160
+gpbeam = 10.537084034522959
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2161 - 2161
+gpbeam = 10.537472058067612
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2162 - 2162
+gpbeam = 10.5372514981068
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2163 - 2163
+gpbeam = 10.537103494033794
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2164 - 2164
+gpbeam = 10.536960521724415
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2165 - 2165
+gpbeam = 10.53703268932394
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2166 - 2166
+gpbeam = 10.537256744821692
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2167 - 2167
+gpbeam = 10.537059841946128
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2168 - 2168
+gpbeam = 10.536793393870397
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2169 - 2169
+gpbeam = 10.536926825526816
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2170 - 2170
+gpbeam = 10.537029677533713
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2171 - 2171
+gpbeam = 10.537723483243855
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2172 - 2172
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2173 - 2173
+gpbeam = 10.537665211506532
+gtargmass_amu = 26.981539
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2174 - 2174
+gpbeam = 10.537487046319859
+gtargmass_amu = 26.981539
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2175 - 2175
+gpbeam = 10.537338700600817
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2176 - 2176
+gpbeam = 10.53868235249079
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2177 - 2177
+gpbeam = 10.537665022551058
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2178 - 2178
+gpbeam = 10.537516856838174
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2179 - 2179
+gpbeam = 10.537523256695593
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2180 - 2180
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2181 - 2181
+gpbeam = 10.537264443716985
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2182 - 2182
+gpbeam = 10.538133799275121
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2183 - 2183
+gpbeam = 10.537536120905136
+gtargmass_amu = 1.007825032
+htheta_lab = -12.370000000000001
+hpcentral = 6.117
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2184 - 2184
+gpbeam = 10.537131065491565
+gtargmass_amu = 12.0107
+htheta_lab = -16.435
+hpcentral = 4.637
+stheta_lab = 28.405
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2185 - 2185
+gpbeam = 10.540481931142118
+gtargmass_amu = 12.0107
+htheta_lab = -16.435
+hpcentral = 4.637
+stheta_lab = 28.405
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2186 - 2186
+gpbeam = 10.53692784523528
+gtargmass_amu = 12.0107
+htheta_lab = -16.435
+hpcentral = 4.637
+stheta_lab = 28.405
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2187 - 2187
+gpbeam = 10.536512853049516
+gtargmass_amu = 12.0107
+htheta_lab = -16.435
+hpcentral = 4.637
+stheta_lab = 28.405
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2188 - 2188
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2189 - 2189
+gpbeam = 10.538024967402862
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2190 - 2190
+gpbeam = 10.537882583500974
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2191 - 2191
+gpbeam = 10.53780877651026
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2192 - 2192
+gpbeam = 10.537806070768687
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2193 - 2193
+gpbeam = 10.537418023393219
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2194 - 2194
+gpbeam = 10.537399835014757
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2195 - 2195
+gpbeam = 10.537555070872367
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2196 - 2196
+gpbeam = 10.53761875728245
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2197 - 2197
+gpbeam = 10.537575575725379
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2198 - 2198
+gpbeam = 10.538254200917677
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2199 - 2199
+gpbeam = 10.537699769690366
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2200 - 2200
+gpbeam = 10.53796902494997
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2201 - 2201
+gpbeam = 10.53770031545364
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2202 - 2202
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2203 - 2203
+gpbeam = 10.537780415970227
+gtargmass_amu = 26.981539
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2204 - 2204
+gpbeam = 10.537484940839915
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2205 - 2205
+gpbeam = 10.53721737793741
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2206 - 2206
+gpbeam = 10.537332419193023
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2207 - 2207
+gpbeam = 10.53724694403471
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2208 - 2208
+gpbeam = 10.537348357127906
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2209 - 2209
+gpbeam = 10.538224707544769
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2210 - 2210
+gpbeam = 10.537176673648997
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2211 - 2211
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2212 - 2212
+gpbeam = 10.537230426334181
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2213 - 2213
+gpbeam = 10.537082480355027
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2214 - 2214
+gpbeam = 10.537892554594691
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2215 - 2215
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2228 - 2228
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2229 - 2229
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2230 - 2230
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2231 - 2231
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2232 - 2232
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2233 - 2233
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2235 - 2235
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2236 - 2236
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2237 - 2237
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2238 - 2238
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2239 - 2239
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2240 - 2240
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2241 - 2241
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2242 - 2242
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2243 - 2243
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2244 - 2244
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2245 - 2245
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2246 - 2246
+gpbeam = 10.537907842053142
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2247 - 2247
+gpbeam = 10.537192538663591
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2248 - 2248
+gpbeam = 10.538141826501553
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2249 - 2249
+gpbeam = 10.537953553113029
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2250 - 2250
+gpbeam = 10.537929242403878
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2251 - 2251
+gpbeam = 10.537802040347554
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2252 - 2252
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2253 - 2253
+gpbeam = 10.537924825224943
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2254 - 2254
+gpbeam = 10.537780370222375
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2255 - 2255
+gpbeam = 10.537839888411861
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2256 - 2256
+gpbeam = 10.537604018455967
+gtargmass_amu = 26.981539
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2257 - 2257
+gpbeam = 10.537381291607337
+gtargmass_amu = 26.981539
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2258 - 2258
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2259 - 2259
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2260 - 2260
+gpbeam = 10.537732522208302
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2261 - 2261
+gpbeam = 10.53735294414979
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2262 - 2262
+gpbeam = 10.537586022547805
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2263 - 2263
+gpbeam = 10.53731600407935
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2264 - 2264
+gpbeam = 10.537594180137217
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2265 - 2265
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2266 - 2266
+gpbeam = 10.537935350641312
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2267 - 2267
+gpbeam = 10.53788004547404
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2268 - 2268
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2269 - 2269
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2270 - 2270
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2271 - 2271
+gpbeam = 10.53833659152617
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2272 - 2272
+gpbeam = 10.538250077562974
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2273 - 2273
+gpbeam = 10.538322396525597
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2274 - 2274
+gpbeam = 10.538237521088345
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2275 - 2275
+gpbeam = 10.538343378053844
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2276 - 2276
+gpbeam = 10.538620392060482
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2277 - 2277
+gpbeam = 10.5383758946093
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2278 - 2278
+gpbeam = 10.53814498540458
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2279 - 2279
+gpbeam = 10.538438710868986
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2280 - 2280
+gpbeam = 10.53837747742135
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2281 - 2281
+gpbeam = 10.538620991017954
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2282 - 2282
+gpbeam = 10.537959752805044
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2283 - 2283
+gpbeam = 10.537970431608848
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2284 - 2284
+gpbeam = 10.537665108827234
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2285 - 2285
+gpbeam = 10.537762918359192
+gtargmass_amu = 26.981539
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2286 - 2286
+gpbeam = 10.537906828908048
+gtargmass_amu = 26.981539
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2287 - 2287
+gpbeam = 10.538373550479884
+gtargmass_amu = 26.981539
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2288 - 2288
+gpbeam = 10.53755737423124
+gtargmass_amu = 26.981539
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2289 - 2289
+gpbeam = 10.537791014039025
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2290 - 2290
+gpbeam = 10.538041599645432
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2291 - 2291
+gpbeam = 10.538034887635842
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2292 - 2292
+gpbeam = 10.537834272356852
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2293 - 2293
+gpbeam = 10.537537289342467
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2294 - 2294
+gpbeam = 10.537686384307081
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2295 - 2295
+gpbeam = 10.537627982670557
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2296 - 2296
+gpbeam = 10.537844226209762
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2297 - 2297
+gpbeam = 10.537729688886069
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2298 - 2298
+gpbeam = 10.537908767298303
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2299 - 2299
+gpbeam = 10.537768393918885
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2300 - 2300
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2301 - 2301
+gpbeam = 10.537923060216807
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2302 - 2302
+gpbeam = 10.537972506105186
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2303 - 2303
+gpbeam = 10.538056820490754
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2304 - 2304
+gpbeam = 10.537828548133792
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2305 - 2305
+gpbeam = 10.538042273945955
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2306 - 2306
+gpbeam = 10.538241030078206
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2307 - 2307
+gpbeam = 10.538201173488853
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2308 - 2308
+gpbeam = 10.538136789764515
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2309 - 2309
+gpbeam = 10.538395101564383
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2310 - 2310
+gpbeam = 10.538191928631162
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2311 - 2311
+gpbeam = 10.537788676913545
+gtargmass_amu = 26.981539
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2312 - 2312
+gpbeam = 10.53771193929635
+gtargmass_amu = 26.981539
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2313 - 2313
+gpbeam = 10.53758960514041
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2314 - 2314
+gpbeam = 10.537616356206774
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2315 - 2315
+gpbeam = 10.537825747871144
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2316 - 2316
+gpbeam = 10.53798534939556
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2317 - 2317
+gpbeam = 10.537588002075513
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2318 - 2318
+gpbeam = 10.537578952207232
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2319 - 2319
+gpbeam = 10.537604559088706
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2320 - 2320
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2321 - 2321
+gpbeam = 10.537925687476527
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2322 - 2322
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2323 - 2323
+gpbeam = 10.53797747303408
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2324 - 2324
+gpbeam = 10.537824827518008
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2325 - 2325
+gpbeam = 10.538087558732306
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2326 - 2326
+gpbeam = 10.538322804164883
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2327 - 2327
+gpbeam = 10.538355875704049
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2328 - 2328
+gpbeam = 10.537980748343111
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2329 - 2329
+gpbeam = 10.538427435751991
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2330 - 2330
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2331 - 2331
+gpbeam = 10.53858111823758
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2332 - 2332
+gpbeam = 10.538099968753853
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2333 - 2333
+gpbeam = 10.538443902497844
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2334 - 2334
+gpbeam = 10.538695649191316
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2335 - 2335
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2336 - 2336
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2337 - 2337
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2338 - 2338
+gpbeam = 10.538218150972185
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2339 - 2339
+gpbeam = 10.5383363598524
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2340 - 2340
+gpbeam = 10.53822460130945
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2341 - 2341
+gpbeam = 10.538219318559143
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2342 - 2342
+gpbeam = 10.53839668782923
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2343 - 2343
+gpbeam = 10.53851141292951
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2344 - 2344
+gpbeam = 10.538424446762454
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2345 - 2345
+gpbeam = 10.538890856139838
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2346 - 2346
+gpbeam = 10.538276801351978
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2347 - 2347
+gpbeam = 10.538451243968794
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2348 - 2348
+gpbeam = 10.538518308528353
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2349 - 2349
+gpbeam = 10.538653311450174
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2350 - 2350
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2351 - 2351
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2352 - 2352
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2353 - 2353
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2354 - 2354
+gpbeam = 10.538378258891766
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2355 - 2355
+gpbeam = 10.538453214489758
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2356 - 2356
+gpbeam = 10.53838708752047
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2357 - 2357
+gpbeam = 10.538565551294198
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2358 - 2358
+gpbeam = 10.538865704473574
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2359 - 2359
+gpbeam = 10.53830134028006
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2360 - 2360
+gpbeam = 10.538289888553562
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2361 - 2361
+gpbeam = 10.538040189149068
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2362 - 2362
+gpbeam = 10.538390365109596
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2363 - 2363
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2364 - 2364
+gpbeam = 10.538138516797671
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2365 - 2365
+gpbeam = 10.538537299985457
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2366 - 2366
+gpbeam = 10.538322792934933
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2367 - 2367
+gpbeam = 10.53830901814392
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2368 - 2368
+gpbeam = 10.53842236247951
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2369 - 2369
+gpbeam = 10.538213164418448
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2370 - 2370
+gpbeam = 10.538848054604
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2371 - 2371
+gpbeam = 10.539006217495045
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2372 - 2372
+gpbeam = 10.539025414349394
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2373 - 2373
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2374 - 2374
+gpbeam = 10.538409882907517
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2375 - 2375
+gpbeam = 10.538589429659144
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2376 - 2376
+gpbeam = 10.53864334449332
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2377 - 2377
+gpbeam = 10.538765368911578
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2378 - 2378
+gpbeam = 10.539084452526067
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2379 - 2379
+gpbeam = 10.538815590548984
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2380 - 2380
+gpbeam = 10.538741527638733
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2381 - 2381
+gpbeam = 10.538723383068087
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2382 - 2382
+gpbeam = 10.539489386634616
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2383 - 2383
+gpbeam = 10.53893939131089
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2384 - 2384
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2385 - 2385
+gpbeam = 10.539210609928059
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2386 - 2386
+gpbeam = 10.539065350438184
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2387 - 2387
+gpbeam = 10.539241687964012
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2388 - 2388
+gpbeam = 10.539437664974663
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2389 - 2389
+gpbeam = 10.539170000368024
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2390 - 2390
+gpbeam = 10.539362891734475
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2391 - 2391
+gpbeam = 10.53999681778694
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2392 - 2392
+gpbeam = 10.53968777120131
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2393 - 2393
+gpbeam = 10.539585105306257
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2394 - 2394
+gpbeam = 10.539136284869828
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2395 - 2395
+gpbeam = 10.539024896477281
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2396 - 2396
+gpbeam = 10.539000358856606
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2397 - 2397
+gpbeam = 10.539625594009214
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2398 - 2398
+gpbeam = 10.539425883465801
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2399 - 2399
+gpbeam = 10.539465268323971
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2400 - 2400
+gpbeam = 10.539870169521484
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2401 - 2401
+gpbeam = 10.539159782072602
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2402 - 2402
+gpbeam = 10.539210729562292
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2403 - 2403
+gpbeam = 10.539128078426462
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2404 - 2404
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2405 - 2405
+gpbeam = 10.539380351579235
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2406 - 2406
+gpbeam = 10.539648470142238
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2407 - 2407
+gpbeam = 10.539552142876175
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2408 - 2408
+gpbeam = 10.539943343199957
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2409 - 2409
+gpbeam = 10.539555359447158
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2410 - 2410
+gpbeam = 10.53918784332908
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2411 - 2411
+gpbeam = 10.539476449914728
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2412 - 2412
+gpbeam = 10.539537140162716
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2413 - 2413
+gpbeam = 10.539552381254428
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2414 - 2414
+gpbeam = 10.539168228614106
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2415 - 2415
+gpbeam = 10.5394314275413
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2416 - 2416
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2417 - 2417
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2418 - 2418
+gpbeam = 10.540142038765488
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2419 - 2419
+gpbeam = 10.539684444112845
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2420 - 2420
+gpbeam = 10.539408794771406
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2421 - 2421
+gpbeam = 10.539572035414166
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2422 - 2422
+gpbeam = 10.539648028585265
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2423 - 2423
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2424 - 2424
+gpbeam = 10.539856642903567
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2425 - 2425
+gpbeam = 10.539484034656947
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2426 - 2426
+gpbeam = 10.539657936179438
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2427 - 2427
+gpbeam = 10.53946102515478
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2428 - 2428
+gpbeam = 10.53947483342332
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2429 - 2429
+gpbeam = 10.539155707693988
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2430 - 2430
+gpbeam = 10.540059718044924
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2431 - 2431
+gpbeam = 10.54000771909384
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2432 - 2432
+gpbeam = 10.539665163454746
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2433 - 2433
+gpbeam = 10.538869096083904
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2434 - 2434
+gpbeam = 10.540122923240672
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2435 - 2435
+gpbeam = 10.540388161266709
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2436 - 2436
+gpbeam = 10.54000275238114
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2437 - 2437
+gpbeam = 10.540560926290677
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2438 - 2438
+gpbeam = 10.541360114475989
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2439 - 2439
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2441 - 2441
+gpbeam = 10.540419867344415
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2442 - 2442
+gpbeam = 10.540695589594302
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2443 - 2443
+gpbeam = 10.540939615467723
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2444 - 2444
+gpbeam = 10.540492263951439
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2445 - 2445
+gpbeam = 10.539200503304864
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2446 - 2446
+gpbeam = 10.54011868772021
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2447 - 2447
+gpbeam = 10.540439644631848
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2448 - 2448
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2449 - 2449
+gpbeam = 10.539957925298442
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2450 - 2450
+gpbeam = 10.540167579658338
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2451 - 2451
+gpbeam = 10.540472058959729
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2452 - 2452
+gpbeam = 10.540530963904216
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2453 - 2453
+gpbeam = 10.540139588775682
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2454 - 2454
+gpbeam = 10.539912429897948
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2455 - 2455
+gpbeam = 10.540328610120577
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2456 - 2456
+gpbeam = 10.539975158587353
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2457 - 2457
+gpbeam = 10.540296992255785
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2458 - 2458
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2459 - 2459
+gpbeam = 10.539555140052824
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2460 - 2460
+gpbeam = 10.539994959054887
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2461 - 2461
+gpbeam = 10.539309997166582
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2462 - 2462
+gpbeam = 10.539671953904737
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2463 - 2463
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2464 - 2464
+gpbeam = 10.539788153934094
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2465 - 2465
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2466 - 2466
+gpbeam = 10.539558331911456
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2467 - 2467
+gpbeam = 10.539178774374811
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2468 - 2468
+gpbeam = 10.538716284774818
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2469 - 2469
+gpbeam = 10.539304420951865
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2470 - 2470
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2471 - 2471
+gpbeam = 10.538912661191842
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2472 - 2472
+gpbeam = 10.53963108546678
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2473 - 2473
+gpbeam = 10.539597254891492
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2474 - 2474
+gpbeam = 10.539937078190327
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2475 - 2475
+gpbeam = 10.539140856073498
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2476 - 2476
+gpbeam = 10.539313895342342
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2477 - 2477
+gpbeam = 10.539254131601338
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2478 - 2478
+gpbeam = 10.539540148959954
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2479 - 2479
+gpbeam = 10.538334175320568
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2480 - 2480
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2481 - 2481
+gpbeam = 10.538693904345724
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2482 - 2482
+gpbeam = 10.538647872366274
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2483 - 2483
+gpbeam = 10.540538741372712
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2484 - 2484
+gpbeam = 10.540529565677652
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2485 - 2485
+gpbeam = 10.540378359537833
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2486 - 2486
+gpbeam = 10.540514564827916
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2487 - 2487
+gpbeam = 10.540628720149142
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2488 - 2488
+gpbeam = 10.540682542285845
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2489 - 2489
+gpbeam = 10.540520015744844
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2490 - 2490
+gpbeam = 10.54057239860674
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2491 - 2491
+gpbeam = 10.541226272768231
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2492 - 2492
+gpbeam = 10.540434124797846
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2493 - 2493
+gpbeam = 10.540940558953647
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2494 - 2494
+gpbeam = 10.539875380423915
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2495 - 2495
+gpbeam = 10.540028398141676
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2496 - 2496
+gpbeam = 10.5404062481978
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2497 - 2497
+gpbeam = 10.54072519659965
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2498 - 2498
+gpbeam = 10.539822468363385
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 31.75
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2499 - 2499
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2500 - 2500
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2501 - 2501
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2502 - 2502
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2503 - 2503
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2504 - 2504
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2505 - 2505
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+#AUTODB STOPPED RUNNING.
+#AUTODB RESTARTED CAM
+
+2523 - 2523
+gpbeam = 10.540112781912542
+gtargmass_amu = 1.007825032
+htheta_lab = -19.31
+hpcentral = 5.253
+stheta_lab = 31.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2524 - 2524
+gpbeam = 10.539780413590274
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2525 - 2525
+gpbeam = 10.539917465367795
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2526 - 2526
+gpbeam = 10.539782887990551
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2527 - 2527
+gpbeam = 10.539668398503856
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2528 - 2528
+gpbeam = 10.539391454780503
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2529 - 2529
+gpbeam = 10.539135671519176
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2530 - 2530
+gpbeam = 10.539152194370077
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2531 - 2531
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2532 - 2532
+gpbeam = 10.53902830033084
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2533 - 2533
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2534 - 2534
+gpbeam = 10.538572871820426
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2535 - 2535
+gpbeam = 10.538834242140089
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2536 - 2536
+gpbeam = 10.538815602136122
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2537 - 2537
+gpbeam = 10.53822257477209
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2538 - 2538
+gpbeam = 10.538414158737323
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2539 - 2539
+gpbeam = 10.53853701380486
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2540 - 2540
+gpbeam = 10.53778479866874
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2541 - 2541
+gpbeam = 10.537678262460906
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2542 - 2542
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2543 - 2543
+gpbeam = 10.537309407964043
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2544 - 2544
+gpbeam = 10.53762291813547
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2545 - 2545
+gpbeam = 10.537515059030245
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2546 - 2546
+gpbeam = 10.537585166479149
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2547 - 2547
+gpbeam = 10.5372239783366
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2548 - 2548
+gpbeam = 10.537089252810615
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2549 - 2549
+gpbeam = 10.537049799331514
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2550 - 2550
+gpbeam = 10.53700849178099
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2551 - 2551
+gpbeam = 10.53704029930674
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2552 - 2552
+gpbeam = 10.536783797419714
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2553 - 2553
+gpbeam = 10.537489556198809
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2554 - 2554
+gpbeam = 10.53752766306877
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2555 - 2555
+gpbeam = 10.537377109694706
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2556 - 2556
+gpbeam = 10.537605713286753
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2557 - 2557
+gpbeam = 10.537321723789775
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2558 - 2558
+gpbeam = 10.537175269708902
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2559 - 2559
+gpbeam = 10.537084821924369
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2560 - 2560
+gpbeam = 10.53683608203046
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2561 - 2561
+gpbeam = 10.537051837998513
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2562 - 2562
+gpbeam = 10.537102287077003
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2563 - 2563
+gpbeam = 10.537109945282845
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2564 - 2564
+gpbeam = 10.53691639218684
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2565 - 2565
+gpbeam = 10.53646688274853
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2566 - 2566
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2567 - 2567
+gpbeam = 10.536932258610337
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2568 - 2568
+gpbeam = 10.536855609494735
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2569 - 2569
+gpbeam = 10.535943891217443
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2570 - 2570
+gpbeam = 10.535797620303189
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2571 - 2571
+gpbeam = 10.536140435901093
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2572 - 2572
+gpbeam = 10.53572244359279
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2573 - 2573
+gpbeam = 10.535682473272937
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2574 - 2574
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2575 - 2575
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2576 - 2576
+gpbeam = 10.539356916532853
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2577 - 2577
+gpbeam = 10.5388921371336
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2578 - 2578
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2579 - 2579
+gpbeam = 10.538645618192666
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2580 - 2580
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2581 - 2581
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2582 - 2582
+gpbeam = 10.539104420289027
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2583 - 2583
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2584 - 2584
+gpbeam = 10.538976808694072
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2585 - 2585
+gpbeam = 10.538622131719062
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2586 - 2586
+gpbeam = 10.5387035905888
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2587 - 2587
+gpbeam = 10.538703109536211
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2588 - 2588
+gpbeam = 10.538677606109623
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2589 - 2589
+gpbeam = 10.538906448447312
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2590 - 2590
+gpbeam = 10.53871612015968
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2591 - 2591
+gpbeam = 10.538974161971346
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2592 - 2592
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2593 - 2593
+gpbeam = 10.538734447516005
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2594 - 2594
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2595 - 2595
+gpbeam = 10.538771034448825
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2596 - 2596
+gpbeam = 10.538747583910842
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2597 - 2597
+gpbeam = 10.539188818558536
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2598 - 2598
+gpbeam = 10.538691319088386
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2599 - 2599
+gpbeam = 10.538848281604333
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2600 - 2600
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2601 - 2601
+gpbeam = 10.53892908036606
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2602 - 2602
+gpbeam = 10.539205073893111
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2603 - 2603
+gpbeam = 10.539142160489522
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2604 - 2604
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2605 - 2605
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2606 - 2606
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2607 - 2607
+gpbeam = 10.539365128597183
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2608 - 2608
+gpbeam = 10.539093222028097
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2609 - 2609
+gpbeam = 10.538852288427346
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2610 - 2610
+gpbeam = 10.538823984974723
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2611 - 2611
+gpbeam = 10.538852569957752
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2612 - 2612
+gpbeam = 10.538917505409735
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2613 - 2613
+gpbeam = 10.539599448037537
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2614 - 2614
+gpbeam = 10.539006947416702
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2615 - 2615
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2616 - 2616
+gpbeam = 10.538880676527944
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2617 - 2617
+gpbeam = 10.538955726926536
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2618 - 2618
+gpbeam = 10.538684972487301
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2619 - 2619
+gpbeam = 10.539030346921232
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2620 - 2620
+gpbeam = 10.53898322555886
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2621 - 2621
+gpbeam = 10.538674171515375
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2622 - 2622
+gpbeam = 10.538963078212616
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2623 - 2623
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2624 - 2624
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2625 - 2625
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2626 - 2626
+gpbeam = 10.539165652218045
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2627 - 2627
+gpbeam = 10.53858606812049
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2628 - 2628
+gpbeam = 10.538549125383252
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2629 - 2629
+gpbeam = 10.538333467455509
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2630 - 2630
+gpbeam = 10.538807393890494
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2631 - 2631
+gpbeam = 10.538640102759885
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2632 - 2632
+gpbeam = 10.539155473945328
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2633 - 2633
+gpbeam = 10.5391199418346
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2634 - 2634
+gpbeam = 10.539454138523851
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2635 - 2635
+gpbeam = 10.539541547413986
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2636 - 2636
+gpbeam = 10.539408727888816
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2637 - 2637
+gpbeam = 10.539555739258656
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2638 - 2638
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2639 - 2639
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2640 - 2640
+gpbeam = 10.539656373632049
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2641 - 2641
+gpbeam = 10.539729214203229
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2642 - 2642
+gpbeam = 10.53961321578465
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2643 - 2643
+gpbeam = 10.539448478448016
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2644 - 2644
+gpbeam = 10.539679457430307
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2645 - 2645
+gpbeam = 10.539540890792399
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2646 - 2646
+gpbeam = 10.539598772305043
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2647 - 2647
+gpbeam = 10.53908317825844
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2648 - 2648
+gpbeam = 10.539184038861485
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2649 - 2649
+gpbeam = 10.539370541429163
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2650 - 2650
+gpbeam = 10.539305271260195
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2651 - 2651
+gpbeam = 10.539449143406788
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2652 - 2652
+gpbeam = 10.539385744622832
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2653 - 2653
+gpbeam = 10.539575264088652
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2654 - 2654
+gpbeam = 10.539189377440564
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2655 - 2655
+gpbeam = 10.539428369398943
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2656 - 2656
+gpbeam = 10.539244526122621
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2657 - 2657
+gpbeam = 10.539229308345684
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2658 - 2658
+gpbeam = 10.539264020947893
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2659 - 2659
+gpbeam = 10.539776258644597
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2660 - 2660
+gpbeam = 10.539657078940568
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2661 - 2661
+gpbeam = 10.540076776943883
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2662 - 2662
+gpbeam = 10.54003314511879
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2663 - 2663
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2664 - 2664
+gpbeam = 10.539576009950899
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2665 - 2665
+gpbeam = 10.53939963687913
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2666 - 2666
+gpbeam = 10.539470091366727
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2667 - 2667
+gpbeam = 10.539805576361571
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2668 - 2668
+gpbeam = 10.5393641635883
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2669 - 2669
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2670 - 2670
+gpbeam = 10.53972777313398
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2671 - 2671
+gpbeam = 10.540015806879142
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2672 - 2672
+gpbeam = 10.539722286019552
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2673 - 2673
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2674 - 2674
+gpbeam = 10.539252324316337
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2675 - 2675
+gpbeam = 10.538790669972942
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2676 - 2676
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2677 - 2677
+gpbeam = 10.538591122341337
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2678 - 2678
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2679 - 2679
+gpbeam = 10.53927294601174
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2680 - 2680
+gpbeam = 10.539462766001602
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2681 - 2681
+gpbeam = 10.539644112658468
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2682 - 2682
+gpbeam = 10.539727647835065
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2683 - 2683
+gpbeam = 10.539435932190143
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2684 - 2684
+gpbeam = 10.539609314253594
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2685 - 2685
+gpbeam = 10.539684015567586
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2686 - 2686
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2687 - 2687
+gpbeam = 10.539381187960839
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2688 - 2688
+gpbeam = 10.539250147694522
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2689 - 2689
+gpbeam = 10.539286166607324
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2690 - 2690
+gpbeam = 10.539777169133762
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2691 - 2691
+gpbeam = 10.539807037794432
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2692 - 2692
+gpbeam = 10.539696330107168
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2693 - 2693
+gpbeam = 10.539657301051893
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2694 - 2694
+gpbeam = 10.539901041721974
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2695 - 2695
+gpbeam = 10.53969487139326
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2696 - 2696
+gpbeam = 10.53977923304846
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2697 - 2697
+gpbeam = 10.539518527311277
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2698 - 2698
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2699 - 2699
+gpbeam = 10.539344497039759
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2700 - 2700
+gpbeam = 10.54001817971343
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2701 - 2701
+gpbeam = 10.539776061978744
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2702 - 2702
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2703 - 2703
+gpbeam = 10.53952814223744
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2704 - 2704
+gpbeam = 10.53954244977882
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2705 - 2705
+gpbeam = 10.539691713538362
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2706 - 2706
+gpbeam = 10.539775303832855
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2707 - 2707
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2708 - 2708
+gpbeam = 10.539441946925901
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2709 - 2709
+gpbeam = 10.539497728547916
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2710 - 2710
+gpbeam = 10.539689474747778
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2711 - 2711
+gpbeam = 10.539835074633086
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2712 - 2712
+gpbeam = 10.539807583646514
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2713 - 2713
+gpbeam = 10.539690076533955
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2714 - 2714
+gpbeam = 10.539641451759996
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2715 - 2715
+gpbeam = 10.539878752052024
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2716 - 2716
+gpbeam = 10.539509722814401
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2717 - 2717
+gpbeam = 10.539758557649666
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2718 - 2718
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2719 - 2719
+gpbeam = 10.539403321405457
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2720 - 2720
+gpbeam = 10.53919248924458
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2721 - 2721
+gpbeam = 10.538934514836365
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2722 - 2722
+gpbeam = 10.539275304314767
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2723 - 2723
+gpbeam = 10.538983651027749
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2724 - 2724
+gpbeam = 10.539219276398406
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2725 - 2725
+gpbeam = 10.53933363841403
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2726 - 2726
+gpbeam = 10.538855828396823
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2727 - 2727
+gpbeam = 10.538903161827204
+gtargmass_amu = 2.014101778
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2728 - 2728
+gpbeam = 10.53922372142335
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2729 - 2729
+gpbeam = 10.538599925500202
+gtargmass_amu = 26.981539
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2730 - 2730
+gpbeam = 10.538466641926624
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2731 - 2731
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 30.69
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2732 - 2732
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 35.03
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2733 - 2733
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2734 - 2734
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2735 - 2735
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2736 - 2736
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2737 - 2737
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2738 - 2738
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2739 - 2739
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2740 - 2740
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2741 - 2741
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2742 - 2742
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.253
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2743 - 2743
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2744 - 2744
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2745 - 2745
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2746 - 2746
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2747 - 2747
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2748 - 2748
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2749 - 2749
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2750 - 2750
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2751 - 2751
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2752 - 2752
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2753 - 2753
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2754 - 2754
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2755 - 2755
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2756 - 2756
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2757 - 2757
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2758 - 2758
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2759 - 2759
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2760 - 2760
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2761 - 2761
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2762 - 2762
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2763 - 2763
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2764 - 2764
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2765 - 2765
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2766 - 2766
+gpbeam = 10.540481931142118
+gtargmass_amu = 0.0
+htheta_lab = -16.91
+hpcentral = 5.878
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2767 - 2767
+gpbeam = 10.539553609359736
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2768 - 2768
+gpbeam = 10.53946370736584
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2769 - 2769
+gpbeam = 10.539151046427097
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2770 - 2770
+gpbeam = 10.53898142624111
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2771 - 2771
+gpbeam = 10.53875448395009
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2772 - 2772
+gpbeam = 10.53934379065971
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2773 - 2773
+gpbeam = 10.539205201692685
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2774 - 2774
+gpbeam = 10.539158920760455
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2775 - 2775
+gpbeam = 10.539035355751688
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2776 - 2776
+gpbeam = 10.539002257715536
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2777 - 2777
+gpbeam = 10.539254352003926
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2778 - 2778
+gpbeam = 10.539354976887598
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2779 - 2779
+gpbeam = 10.5393970380419
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2780 - 2780
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2781 - 2781
+gpbeam = 10.53889733816495
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2782 - 2782
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2783 - 2783
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2784 - 2784
+gpbeam = 10.539064837733111
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2785 - 2785
+gpbeam = 10.539231859235922
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2786 - 2786
+gpbeam = 10.53899813782569
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2787 - 2787
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2788 - 2788
+gpbeam = 10.538981879956058
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2789 - 2789
+gpbeam = 10.539085410539203
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2790 - 2790
+gpbeam = 10.538793529894845
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2791 - 2791
+gpbeam = 10.538881977348142
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2792 - 2792
+gpbeam = 10.538953963257592
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2793 - 2793
+gpbeam = 10.53946986689397
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2794 - 2794
+gpbeam = 10.539298047152977
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2795 - 2795
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2796 - 2796
+gpbeam = 10.539165265418434
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2797 - 2797
+gpbeam = 10.5390924086009
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2798 - 2798
+gpbeam = 10.539406071455714
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2799 - 2799
+gpbeam = 10.53929524835044
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2800 - 2800
+gpbeam = 10.539458350507868
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2801 - 2801
+gpbeam = 10.539648490050507
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2802 - 2802
+gpbeam = 10.539612667640712
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2803 - 2803
+gpbeam = 10.539858187417645
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2804 - 2804
+gpbeam = 10.539733344131406
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2805 - 2805
+gpbeam = 10.53966567270362
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2806 - 2806
+gpbeam = 10.539221396117917
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2807 - 2807
+gpbeam = 10.539101589588997
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2808 - 2808
+gpbeam = 10.539277287122477
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2809 - 2809
+gpbeam = 10.539256234914374
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2810 - 2810
+gpbeam = 10.538956754781047
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2811 - 2811
+gpbeam = 10.539198669296079
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2812 - 2812
+gpbeam = 10.539012288183045
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2813 - 2813
+gpbeam = 10.539525688047515
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2814 - 2814
+gpbeam = 10.539445907869
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2815 - 2815
+gpbeam = 10.539550888837406
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2816 - 2816
+gpbeam = 10.5393790086206
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2817 - 2817
+gpbeam = 10.53945168273863
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2818 - 2818
+gpbeam = 10.539156920238037
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2819 - 2819
+gpbeam = 10.539244369898611
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2820 - 2820
+gpbeam = 10.539529518895758
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2821 - 2821
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2822 - 2822
+gpbeam = 10.539202702606744
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2823 - 2823
+gpbeam = 10.539301182145936
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2824 - 2824
+gpbeam = 10.539273254338609
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2825 - 2825
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2826 - 2826
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2827 - 2827
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2828 - 2828
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2829 - 2829
+gpbeam = 10.539512996120598
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2830 - 2830
+gpbeam = 10.539598281736245
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2831 - 2831
+gpbeam = 10.53946557797705
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2832 - 2832
+gpbeam = 10.539897482878656
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2833 - 2833
+gpbeam = 10.539551930642888
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2834 - 2834
+gpbeam = 10.539468181331445
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2836 - 2836
+gpbeam = 10.539770623085706
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2837 - 2837
+gpbeam = 10.539572519081764
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2838 - 2838
+gpbeam = 10.540481931142118
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2839 - 2839
+gpbeam = 10.539468105963085
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2840 - 2840
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2841 - 2841
+gpbeam = 10.539220828955528
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2842 - 2842
+gpbeam = 10.539303729105342
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2843 - 2843
+gpbeam = 10.539596292517896
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2844 - 2844
+gpbeam = 10.539492239837825
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2845 - 2845
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2846 - 2846
+gpbeam = 10.539714240166028
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2847 - 2847
+gpbeam = 10.53956495752156
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2848 - 2848
+gpbeam = 10.540481931142118
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2849 - 2849
+gpbeam = 10.539237001593637
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2850 - 2850
+gpbeam = 10.539294002457797
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2851 - 2851
+gpbeam = 10.539366779348862
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2852 - 2852
+gpbeam = 10.539486755360658
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2853 - 2853
+gpbeam = 10.53930588102201
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2854 - 2854
+gpbeam = 10.539300240494764
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 34.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2855 - 2855
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2856 - 2856
+gpbeam = 10.539573951309864
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2857 - 2857
+gpbeam = 10.539282202866373
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2858 - 2858
+gpbeam = 10.539193480195864
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2859 - 2859
+gpbeam = 10.539277622077025
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2860 - 2860
+gpbeam = 10.539067184179112
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 30.830000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2861 - 2861
+gpbeam = 10.539021136894174
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 30.830000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2862 - 2862
+gpbeam = 10.5388634792636
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2863 - 2863
+gpbeam = 10.538909482222392
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2864 - 2864
+gpbeam = 10.53927815897094
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2865 - 2865
+gpbeam = 10.539121017118356
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2866 - 2866
+gpbeam = 10.53907970649475
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2867 - 2867
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2868 - 2868
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 30.830000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2869 - 2869
+gpbeam = 10.539749612100323
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 30.830000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2870 - 2870
+gpbeam = 10.539584677483894
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 30.830000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2871 - 2871
+gpbeam = 10.539595315342474
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 30.830000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2872 - 2872
+gpbeam = 10.539541823691957
+gtargmass_amu = 1.007825032
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2873 - 2873
+gpbeam = 10.53941557911988
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2874 - 2874
+gpbeam = 10.539187289545596
+gtargmass_amu = 2.014101778
+htheta_lab = -16.43
+hpcentral = 4.637
+stheta_lab = 28.41
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2875 - 2875
+gpbeam = 10.539417930253727
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2876 - 2876
+gpbeam = 10.539421591825278
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2877 - 2877
+gpbeam = 10.539293490558318
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2878 - 2878
+gpbeam = 10.539680950623083
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2879 - 2879
+gpbeam = 10.539451177104198
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 30.830000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2880 - 2880
+gpbeam = 10.539799966988188
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 30.830000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2881 - 2881
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 30.830000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2882 - 2882
+gpbeam = 10.540481931142118
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2883 - 2883
+gpbeam = 10.539269838753347
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2884 - 2884
+gpbeam = 10.539203179730409
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2885 - 2885
+gpbeam = 10.539350817036663
+gtargmass_amu = 1.007825032
+htheta_lab = -29.86
+hpcentral = 4.0872
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2886 - 2886
+gpbeam = 8.45950603828208
+gtargmass_amu = 12.0107
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2887 - 2887
+gpbeam = 8.457894704697138
+gtargmass_amu = 12.0107
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2888 - 2888
+gpbeam = 8.457894704697138
+gtargmass_amu = 12.0107
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2889 - 2889
+gpbeam = 8.457894704697138
+gtargmass_amu = 12.0107
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2890 - 2890
+gpbeam = 8.457894704697138
+gtargmass_amu = 12.0107
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2891 - 2891
+gpbeam = 8.457894704697138
+gtargmass_amu = 12.0107
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2892 - 2892
+gpbeam = 8.457894704697138
+gtargmass_amu = 12.0107
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2893 - 2893
+gpbeam = 8.457894704697138
+gtargmass_amu = 12.0107
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2894 - 2894
+gpbeam = 8.457894704697138
+gtargmass_amu = 12.0107
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2895 - 2895
+gpbeam = 8.457894704697138
+gtargmass_amu = 12.0107
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2896 - 2896
+gpbeam = 8.457894704697138
+gtargmass_amu = 12.0107
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2897 - 2897
+gpbeam = 8.457894704697138
+gtargmass_amu = 12.0107
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2898 - 2898
+gpbeam = 8.456877336145974
+gtargmass_amu = 12.0107
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2899 - 2899
+gpbeam = 8.457013681954313
+gtargmass_amu = 12.0107
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2900 - 2900
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2901 - 2901
+gpbeam = 8.456832953409474
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2902 - 2902
+gpbeam = 8.456760402908515
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2903 - 2903
+gpbeam = 8.456790931260558
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2904 - 2904
+gpbeam = 8.456855582386119
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2905 - 2905
+gpbeam = 8.456715648683485
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2906 - 2906
+gpbeam = 8.456692170177751
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2907 - 2907
+gpbeam = 8.456697276309717
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2908 - 2908
+gpbeam = 8.45678240520217
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2909 - 2909
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2910 - 2910
+gpbeam = 8.456920339866556
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2911 - 2911
+gpbeam = 8.456962513648614
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2912 - 2912
+gpbeam = 8.45681461476115
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2913 - 2913
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2914 - 2914
+gpbeam = 8.456789193723568
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2915 - 2915
+gpbeam = 8.456779037547381
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2916 - 2916
+gpbeam = 8.456688031516258
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2917 - 2917
+gpbeam = 8.456889075543106
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2918 - 2918
+gpbeam = 8.456882835770362
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2919 - 2919
+gpbeam = 8.45679600323369
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2920 - 2920
+gpbeam = 8.456688031516258
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+;AUTODB SCRIPT STOPPED WORKING
+;Everything appears to be junk here.
+;Beam was down for this period (labeled JUNK)
+
+2935 - 2935
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2936 - 2936
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2937 - 2937
+gpbeam = 0.0
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2938 - 2938
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2939 - 2939
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2940 - 2940
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2941 - 2941
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2942 - 2942
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2943 - 2943
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2944 - 2944
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2945 - 2945
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.36
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2946 - 2946
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.36
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2947 - 2947
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.36
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2948 - 2948
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.36
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2949 - 2949
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.36
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2950 - 2950
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.35
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2951 - 2951
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.35
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2952 - 2952
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2953 - 2953
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2954 - 2954
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2955 - 2955
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2956 - 2956
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2957 - 2957
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2958 - 2958
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2959 - 2959
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2960 - 2960
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2961 - 2961
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2962 - 2962
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2963 - 2963
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2964 - 2964
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2965 - 2965
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2966 - 2966
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2967 - 2967
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2968 - 2968
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2969 - 2969
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2970 - 2970
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2971 - 2971
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -27.62
+hpcentral = 4.12
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+2972 - 2972
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2973 - 2973
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2974 - 2974
+gpbeam = 8.45701354008917
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2975 - 2975
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2976 - 2976
+gpbeam = 8.456698530285331
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2977 - 2977
+gpbeam = 8.45677631828353
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2978 - 2978
+gpbeam = 8.456894497419574
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2979 - 2979
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2980 - 2980
+gpbeam = 8.456812680370618
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2981 - 2981
+gpbeam = 8.456954252979903
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2982 - 2982
+gpbeam = 8.45675370756837
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2983 - 2983
+gpbeam = 8.456749262962608
+gtargmass_amu = 26.981539
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2983 - 2983
+gpbeam = 8.456749262962608
+gtargmass_amu = 26.981539
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2984 - 2984
+gpbeam = 8.45702131214645
+gtargmass_amu = 26.981539
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2984 - 2984
+gpbeam = 8.45702131214645
+gtargmass_amu = 26.981539
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2985 - 2985
+gpbeam = 8.457275605777607
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2985 - 2985
+gpbeam = 8.457275605777607
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2986 - 2986
+gpbeam = 8.456922370850213
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2986 - 2986
+gpbeam = 8.456922370850213
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2987 - 2987
+gpbeam = 8.456700565888342
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2987 - 2987
+gpbeam = 8.456700565888342
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2988 - 2988
+gpbeam = 8.456529537847928
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2988 - 2988
+gpbeam = 8.456529537847928
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2989 - 2989
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2989 - 2989
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2990 - 2990
+gpbeam = 8.45678064676724
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2990 - 2990
+gpbeam = 8.45678064676724
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2991 - 2991
+gpbeam = 8.456888882946428
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2991 - 2991
+gpbeam = 8.456888882946428
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2992 - 2992
+gpbeam = 8.45690015279178
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2992 - 2992
+gpbeam = 8.45690015279178
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2993 - 2993
+gpbeam = 8.456897399315702
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2993 - 2993
+gpbeam = 8.456897399315702
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2994 - 2994
+gpbeam = 8.45680413034317
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2994 - 2994
+gpbeam = 8.45680413034317
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2995 - 2995
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2995 - 2995
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2996 - 2996
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2996 - 2996
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2997 - 2997
+gpbeam = 8.456692083473753
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2997 - 2997
+gpbeam = 8.456692083473753
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2998 - 2998
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2998 - 2998
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2999 - 2999
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+2999 - 2999
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3000 - 3000
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3000 - 3000
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3001 - 3001
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3001 - 3001
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 36.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3002 - 3002
+gpbeam = 8.456562362065549
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3002 - 3002
+gpbeam = 8.456562362065549
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3003 - 3003
+gpbeam = 8.456723975355995
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3003 - 3003
+gpbeam = 8.456723975355995
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3004 - 3004
+gpbeam = 8.456680132753727
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3004 - 3004
+gpbeam = 8.456680132753727
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3005 - 3005
+gpbeam = 8.456637627060461
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3005 - 3005
+gpbeam = 8.456637627060461
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3006 - 3006
+gpbeam = 8.456726650886147
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3006 - 3006
+gpbeam = 8.456726650886147
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3007 - 3007
+gpbeam = 8.456523785697026
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3007 - 3007
+gpbeam = 8.456523785697026
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3008 - 3008
+gpbeam = 8.456572961048527
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3008 - 3008
+gpbeam = 8.456572961048527
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3009 - 3009
+gpbeam = 8.456516039027429
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3009 - 3009
+gpbeam = 8.456516039027429
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3010 - 3010
+gpbeam = 8.456452998250471
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3010 - 3010
+gpbeam = 8.456452998250471
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3011 - 3011
+gpbeam = 8.456544882590297
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3011 - 3011
+gpbeam = 8.456544882590297
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3012 - 3012
+gpbeam = 8.456673498270595
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3012 - 3012
+gpbeam = 8.456673498270595
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3013 - 3013
+gpbeam = 8.45664701195461
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3013 - 3013
+gpbeam = 8.45664701195461
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3014 - 3014
+gpbeam = 8.456744676888375
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3014 - 3014
+gpbeam = 8.456744676888375
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3015 - 3015
+gpbeam = 8.456642338318739
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3015 - 3015
+gpbeam = 8.456642338318739
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3016 - 3016
+gpbeam = 8.456782014697353
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3016 - 3016
+gpbeam = 8.456782014697353
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3017 - 3017
+gpbeam = 8.456687025277892
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3017 - 3017
+gpbeam = 8.456687025277892
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3018 - 3018
+gpbeam = 8.456681516211844
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3018 - 3018
+gpbeam = 8.456681516211844
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3019 - 3019
+gpbeam = 8.456612712157431
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3019 - 3019
+gpbeam = 8.456612712157431
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3020 - 3020
+gpbeam = 8.456784308053384
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3020 - 3020
+gpbeam = 8.456784308053384
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3021 - 3021
+gpbeam = 8.456713569438866
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3021 - 3021
+gpbeam = 8.456713569438866
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3022 - 3022
+gpbeam = 8.4567117775168
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3022 - 3022
+gpbeam = 8.4567117775168
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3023 - 3023
+gpbeam = 8.456709515218684
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3023 - 3023
+gpbeam = 8.456709515218684
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3024 - 3024
+gpbeam = 8.457894704697138
+gtargmass_amu = 26.981539
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3024 - 3024
+gpbeam = 8.457894704697138
+gtargmass_amu = 26.981539
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3025 - 3025
+gpbeam = 8.457894704697138
+gtargmass_amu = 26.981539
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3025 - 3025
+gpbeam = 8.457894704697138
+gtargmass_amu = 26.981539
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3026 - 3026
+gpbeam = 8.456774340248675
+gtargmass_amu = 26.981539
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3026 - 3026
+gpbeam = 8.456774340248675
+gtargmass_amu = 26.981539
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3027 - 3027
+gpbeam = 8.456688797568418
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3027 - 3027
+gpbeam = 8.456688797568418
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3028 - 3028
+gpbeam = 8.45668084802308
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3028 - 3028
+gpbeam = 8.45668084802308
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3029 - 3029
+gpbeam = 8.456760429609265
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3029 - 3029
+gpbeam = 8.456760429609265
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3030 - 3030
+gpbeam = 8.456596962724552
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3030 - 3030
+gpbeam = 8.456596962724552
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3031 - 3031
+gpbeam = 8.456705781533165
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3031 - 3031
+gpbeam = 8.456705781533165
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3032 - 3032
+gpbeam = 8.456722403488639
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3032 - 3032
+gpbeam = 8.456722403488639
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3033 - 3033
+gpbeam = 8.4567266633986
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3033 - 3033
+gpbeam = 8.4567266633986
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3034 - 3034
+gpbeam = 8.456631006002924
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3034 - 3034
+gpbeam = 8.456631006002924
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3035 - 3035
+gpbeam = 8.45677390473946
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3035 - 3035
+gpbeam = 8.45677390473946
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3036 - 3036
+gpbeam = 8.456708907917873
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3036 - 3036
+gpbeam = 8.456708907917873
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3037 - 3037
+gpbeam = 8.456898310353802
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3037 - 3037
+gpbeam = 8.456898310353802
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3038 - 3038
+gpbeam = 8.456603618046893
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3038 - 3038
+gpbeam = 8.456603618046893
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3039 - 3039
+gpbeam = 8.456546495429553
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3039 - 3039
+gpbeam = 8.456546495429553
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3040 - 3040
+gpbeam = 8.456659617631638
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3040 - 3040
+gpbeam = 8.456659617631638
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3041 - 3041
+gpbeam = 8.45654173943189
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3041 - 3041
+gpbeam = 8.45654173943189
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3042 - 3042
+gpbeam = 8.456461842458536
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3042 - 3042
+gpbeam = 8.456461842458536
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3043 - 3043
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3043 - 3043
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3044 - 3044
+gpbeam = 8.456544644184047
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3044 - 3044
+gpbeam = 8.456544644184047
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3045 - 3045
+gpbeam = 8.456528390939487
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3045 - 3045
+gpbeam = 8.456528390939487
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3046 - 3046
+gpbeam = 8.456603772148025
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3046 - 3046
+gpbeam = 8.456603772148025
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3048 - 3048
+gpbeam = 8.45666850443634
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3048 - 3048
+gpbeam = 8.45666850443634
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3049 - 3049
+gpbeam = 8.456535657975163
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3049 - 3049
+gpbeam = 8.456535657975163
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3050 - 3050
+gpbeam = 8.456624040585892
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3050 - 3050
+gpbeam = 8.456624040585892
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3051 - 3051
+gpbeam = 8.45654368496649
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3051 - 3051
+gpbeam = 8.45654368496649
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3052 - 3052
+gpbeam = 8.456487379221496
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3052 - 3052
+gpbeam = 8.456487379221496
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3053 - 3053
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3053 - 3053
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3054 - 3054
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3054 - 3054
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3055 - 3055
+gpbeam = 8.4563015364003
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3055 - 3055
+gpbeam = 8.4563015364003
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3056 - 3056
+gpbeam = 8.456332455715874
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3056 - 3056
+gpbeam = 8.456332455715874
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3057 - 3057
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3057 - 3057
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3058 - 3058
+gpbeam = 8.456459365491979
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3058 - 3058
+gpbeam = 8.456459365491979
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3059 - 3059
+gpbeam = 8.456419828713152
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3059 - 3059
+gpbeam = 8.456419828713152
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3060 - 3060
+gpbeam = 8.456373765416451
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3060 - 3060
+gpbeam = 8.456373765416451
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3061 - 3061
+gpbeam = 8.456061757375856
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3061 - 3061
+gpbeam = 8.456061757375856
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3062 - 3062
+gpbeam = 8.456352460669438
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3062 - 3062
+gpbeam = 8.456352460669438
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 30.66
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3063 - 3063
+gpbeam = 8.456431928419867
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3063 - 3063
+gpbeam = 8.456431928419867
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3064 - 3064
+gpbeam = 8.456307771135398
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3064 - 3064
+gpbeam = 8.456307771135398
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3065 - 3065
+gpbeam = 8.456256826205292
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3065 - 3065
+gpbeam = 8.456256826205292
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3066 - 3066
+gpbeam = 8.456297114165743
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3066 - 3066
+gpbeam = 8.456297114165743
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3067 - 3067
+gpbeam = 8.456340807762805
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3067 - 3067
+gpbeam = 8.456340807762805
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3068 - 3068
+gpbeam = 8.456316573277665
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3068 - 3068
+gpbeam = 8.456316573277665
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3069 - 3069
+gpbeam = 8.456425582590994
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3069 - 3069
+gpbeam = 8.456425582590994
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3070 - 3070
+gpbeam = 8.456283158067889
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3070 - 3070
+gpbeam = 8.456283158067889
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3071 - 3071
+gpbeam = 8.456325603733633
+gtargmass_amu = 26.981539
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3071 - 3071
+gpbeam = 8.456325603733633
+gtargmass_amu = 26.981539
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3072 - 3072
+gpbeam = 8.456431569642294
+gtargmass_amu = 26.981539
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3072 - 3072
+gpbeam = 8.456431569642294
+gtargmass_amu = 26.981539
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3073 - 3073
+gpbeam = 8.455984101170717
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3073 - 3073
+gpbeam = 8.455984101170717
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3074 - 3074
+gpbeam = 8.456028575610988
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3074 - 3074
+gpbeam = 8.456028575610988
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3075 - 3075
+gpbeam = 8.456079931398076
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3075 - 3075
+gpbeam = 8.456079931398076
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3076 - 3076
+gpbeam = 8.456285882623893
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3076 - 3076
+gpbeam = 8.456285882623893
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3077 - 3077
+gpbeam = 8.456298027993839
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3077 - 3077
+gpbeam = 8.456298027993839
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3078 - 3078
+gpbeam = 8.456361519594676
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3078 - 3078
+gpbeam = 8.456361519594676
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3079 - 3079
+gpbeam = 8.456196803523286
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3079 - 3079
+gpbeam = 8.456196803523286
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3080 - 3080
+gpbeam = 8.455933302762675
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3080 - 3080
+gpbeam = 8.455933302762675
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3081 - 3081
+gpbeam = 8.455886374669703
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3081 - 3081
+gpbeam = 8.455886374669703
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3082 - 3082
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3082 - 3082
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3083 - 3083
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3083 - 3083
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3084 - 3084
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3084 - 3084
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3085 - 3085
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3085 - 3085
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3086 - 3086
+gpbeam = 8.456370885894062
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3086 - 3086
+gpbeam = 8.456370885894062
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3087 - 3087
+gpbeam = 8.45639814603695
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3087 - 3087
+gpbeam = 8.45639814603695
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3088 - 3088
+gpbeam = 8.456234299605194
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3088 - 3088
+gpbeam = 8.456234299605194
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3089 - 3089
+gpbeam = 8.456242916603713
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3089 - 3089
+gpbeam = 8.456242916603713
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3090 - 3090
+gpbeam = 8.456521246327767
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3090 - 3090
+gpbeam = 8.456521246327767
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3091 - 3091
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3091 - 3091
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3092 - 3092
+gpbeam = 8.45619824831232
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3092 - 3092
+gpbeam = 8.45619824831232
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3093 - 3093
+gpbeam = 8.456242832028778
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3093 - 3093
+gpbeam = 8.456242832028778
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3094 - 3094
+gpbeam = 8.456137712860867
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3094 - 3094
+gpbeam = 8.456137712860867
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3095 - 3095
+gpbeam = 8.456166255700209
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3095 - 3095
+gpbeam = 8.456166255700209
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3096 - 3096
+gpbeam = 8.456058507628516
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3096 - 3096
+gpbeam = 8.456058507628516
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3097 - 3097
+gpbeam = 8.456038038053812
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3097 - 3097
+gpbeam = 8.456038038053812
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3098 - 3098
+gpbeam = 8.456206547673059
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3098 - 3098
+gpbeam = 8.456206547673059
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3099 - 3099
+gpbeam = 8.456150273604635
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3099 - 3099
+gpbeam = 8.456150273604635
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3100 - 3100
+gpbeam = 8.456075927542175
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3100 - 3100
+gpbeam = 8.456075927542175
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3101 - 3101
+gpbeam = 8.455856164453007
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3101 - 3101
+gpbeam = 8.455856164453007
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3102 - 3102
+gpbeam = 8.456300946211819
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3102 - 3102
+gpbeam = 8.456300946211819
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3103 - 3103
+gpbeam = 8.456005633410411
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3103 - 3103
+gpbeam = 8.456005633410411
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3104 - 3104
+gpbeam = 8.456074644104419
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3104 - 3104
+gpbeam = 8.456074644104419
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3105 - 3105
+gpbeam = 8.456055107272046
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3105 - 3105
+gpbeam = 8.456055107272046
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 32.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3106 - 3106
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3106 - 3106
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3107 - 3107
+gpbeam = 8.456006233591799
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3107 - 3107
+gpbeam = 8.456006233591799
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3108 - 3108
+gpbeam = 8.455854410852606
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3108 - 3108
+gpbeam = 8.455854410852606
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3109 - 3109
+gpbeam = 8.455594081179571
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3109 - 3109
+gpbeam = 8.455594081179571
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3110 - 3110
+gpbeam = 8.456194867945014
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3110 - 3110
+gpbeam = 8.456194867945014
+gtargmass_amu = 1.007825032
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3111 - 3111
+gpbeam = 8.456021363670907
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3111 - 3111
+gpbeam = 8.456021363670907
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3112 - 3112
+gpbeam = 8.456264747524358
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3112 - 3112
+gpbeam = 8.456264747524358
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3113 - 3113
+gpbeam = 8.456516006388213
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3113 - 3113
+gpbeam = 8.456516006388213
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.042
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3114 - 3114
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.726
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3114 - 3114
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.726
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3115 - 3115
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.726
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3115 - 3115
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.726
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3116 - 3116
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.726
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3116 - 3116
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -17.01
+hpcentral = 4.726
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3117 - 3117
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3117 - 3117
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3118 - 3118
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3118 - 3118
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3119 - 3119
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3119 - 3119
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3120 - 3120
+gpbeam = 8.45641646098296
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3120 - 3120
+gpbeam = 8.45641646098296
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3121 - 3121
+gpbeam = 8.456801535579586
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3121 - 3121
+gpbeam = 8.456801535579586
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3122 - 3122
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3122 - 3122
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3123 - 3123
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3124 - 3124
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3125 - 3125
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3126 - 3126
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3127 - 3127
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3128 - 3128
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3129 - 3129
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3130 - 3130
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3131 - 3131
+gpbeam = 8.457894704697138
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3132 - 3132
+gpbeam = 8.457894704697138
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3133 - 3133
+gpbeam = 8.457894704697138
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3134 - 3134
+gpbeam = 8.457894704697138
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3135 - 3135
+gpbeam = 8.457894704697138
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3136 - 3136
+gpbeam = 8.457894704697138
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3137 - 3137
+gpbeam = 8.457894704697138
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3138 - 3138
+gpbeam = 8.456663855167859
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3139 - 3139
+gpbeam = 8.456639406375418
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3140 - 3140
+gpbeam = 8.45660109284763
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3141 - 3141
+gpbeam = 8.456632073870104
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3142 - 3142
+gpbeam = 8.456336496706752
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3143 - 3143
+gpbeam = 8.456446658589899
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3144 - 3144
+gpbeam = 8.456470364716761
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3145 - 3145
+gpbeam = 8.4566540602827
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3146 - 3146
+gpbeam = 8.456603538763892
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3147 - 3147
+gpbeam = 8.456430977052243
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3148 - 3148
+gpbeam = 8.4563452419198
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3149 - 3149
+gpbeam = 8.456371339897807
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3150 - 3150
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3151 - 3151
+gpbeam = 8.456400381044139
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3152 - 3152
+gpbeam = 8.456135396565106
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3153 - 3153
+gpbeam = 8.456416599090929
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3154 - 3154
+gpbeam = 8.456223749638747
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3155 - 3155
+gpbeam = 8.456076072012412
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3156 - 3156
+gpbeam = 8.456310540140452
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3157 - 3157
+gpbeam = 8.45605562662147
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3158 - 3158
+gpbeam = 8.455881162137752
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3159 - 3159
+gpbeam = 8.457894704697138
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3160 - 3160
+gpbeam = 8.456006375471807
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3161 - 3161
+gpbeam = 8.45541318304616
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3162 - 3162
+gpbeam = 8.456162022293228
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3163 - 3163
+gpbeam = 8.456295429239338
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3164 - 3164
+gpbeam = 8.456304165125854
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3165 - 3165
+gpbeam = 8.456137873636374
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3166 - 3166
+gpbeam = 8.456226924072553
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3167 - 3167
+gpbeam = 8.455800623613463
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3168 - 3168
+gpbeam = 8.456053485255365
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3169 - 3169
+gpbeam = 8.456160199458129
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3170 - 3170
+gpbeam = 8.456048150911382
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3171 - 3171
+gpbeam = 8.455794422771541
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3172 - 3172
+gpbeam = 8.456122891730603
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3173 - 3173
+gpbeam = 8.455838232622089
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3174 - 3174
+gpbeam = 8.455946491818123
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3175 - 3175
+gpbeam = 8.455969180914547
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3176 - 3176
+gpbeam = 8.456107069694983
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3177 - 3177
+gpbeam = 8.455952747323147
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3178 - 3178
+gpbeam = 8.455993433547441
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3179 - 3179
+gpbeam = 8.455744912637508
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3180 - 3180
+gpbeam = 8.455724757320818
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3181 - 3181
+gpbeam = 8.455744915241459
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3182 - 3182
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3183 - 3183
+gpbeam = 8.45590187231848
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3184 - 3184
+gpbeam = 8.45600315653497
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3185 - 3185
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3186 - 3186
+gpbeam = 8.455889830647198
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3187 - 3187
+gpbeam = 8.456095209634633
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3188 - 3188
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3189 - 3189
+gpbeam = 8.455674882137385
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3190 - 3190
+gpbeam = 8.45550108041178
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3191 - 3191
+gpbeam = 8.455534355072185
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3192 - 3192
+gpbeam = 8.455626055374559
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3193 - 3193
+gpbeam = 8.45575822557982
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3194 - 3194
+gpbeam = 8.455275871044927
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3195 - 3195
+gpbeam = 8.455593455606278
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3196 - 3196
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3197 - 3197
+gpbeam = 8.45525455984651
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3198 - 3198
+gpbeam = 8.455377265721902
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3199 - 3199
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3200 - 3200
+gpbeam = 8.454837401792162
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3201 - 3201
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3202 - 3202
+gpbeam = 8.454577686604557
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3203 - 3203
+gpbeam = 8.454425479931148
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3204 - 3204
+gpbeam = 8.454549661031205
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3205 - 3205
+gpbeam = 8.454824853527912
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3206 - 3206
+gpbeam = 8.454576333559851
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3207 - 3207
+gpbeam = 8.454597342552129
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3208 - 3208
+gpbeam = 8.454870319702463
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3209 - 3209
+gpbeam = 8.454647889032417
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3210 - 3210
+gpbeam = 8.454771175959978
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3211 - 3211
+gpbeam = 8.454711920779928
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3212 - 3212
+gpbeam = 8.454988142789418
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3213 - 3213
+gpbeam = 8.454571855495141
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3214 - 3214
+gpbeam = 8.45416206331358
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3215 - 3215
+gpbeam = 8.454884105617596
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3216 - 3216
+gpbeam = 8.454953827476174
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3217 - 3217
+gpbeam = 8.454872818705152
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3218 - 3218
+gpbeam = 8.454684496993204
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3219 - 3219
+gpbeam = 8.454518204348371
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3220 - 3220
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3221 - 3221
+gpbeam = 8.454840092901316
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3222 - 3222
+gpbeam = 8.454265415355739
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3223 - 3223
+gpbeam = 8.454338169169779
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3224 - 3224
+gpbeam = 8.454788311980638
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3225 - 3225
+gpbeam = 8.45434800901633
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3226 - 3226
+gpbeam = 8.454026466872985
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3227 - 3227
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3228 - 3228
+gpbeam = 8.454368698182767
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3229 - 3229
+gpbeam = 8.454020005467283
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3230 - 3230
+gpbeam = 8.453971177259321
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3231 - 3231
+gpbeam = 8.454279614913235
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3232 - 3232
+gpbeam = 8.454460171502957
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3233 - 3233
+gpbeam = 8.454696345191339
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3234 - 3234
+gpbeam = 8.454778578031934
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3235 - 3235
+gpbeam = 8.454920563267116
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3236 - 3236
+gpbeam = 8.45422203291759
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3237 - 3237
+gpbeam = 8.45429740695167
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3238 - 3238
+gpbeam = 8.454461462077242
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3239 - 3239
+gpbeam = 8.45614123702018
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3240 - 3240
+gpbeam = 8.45595088104788
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3241 - 3241
+gpbeam = 8.454814751863442
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3242 - 3242
+gpbeam = 8.455234810680597
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3243 - 3243
+gpbeam = 8.454596188625805
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3244 - 3244
+gpbeam = 8.455134684360086
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3245 - 3245
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3246 - 3246
+gpbeam = 8.454658034375763
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3247 - 3247
+gpbeam = 8.454339141001194
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3248 - 3248
+gpbeam = 8.454537230797031
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3249 - 3249
+gpbeam = 8.454631665604381
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3250 - 3250
+gpbeam = 8.454808791995498
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3251 - 3251
+gpbeam = 8.454333907404678
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3252 - 3252
+gpbeam = 8.454524999697552
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3253 - 3253
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3254 - 3254
+gpbeam = 8.45400382261643
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3255 - 3255
+gpbeam = 8.45392625244558
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3256 - 3256
+gpbeam = 8.453573724423896
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3257 - 3257
+gpbeam = 8.453806048574984
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3258 - 3258
+gpbeam = 8.453946581114721
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3259 - 3259
+gpbeam = 8.454031871208777
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3260 - 3260
+gpbeam = 8.454480654048929
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3261 - 3261
+gpbeam = 8.454848177318555
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3262 - 3262
+gpbeam = 8.454444807793756
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3263 - 3263
+gpbeam = 8.454641349604485
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3264 - 3264
+gpbeam = 8.454543075982842
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3265 - 3265
+gpbeam = 8.454564425880738
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3266 - 3266
+gpbeam = 8.45475097930168
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3267 - 3267
+gpbeam = 8.454836120632102
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3268 - 3268
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3269 - 3269
+gpbeam = 8.454588003933821
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3270 - 3270
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3271 - 3271
+gpbeam = 8.454870224597109
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3272 - 3272
+gpbeam = 8.454441858303516
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3273 - 3273
+gpbeam = 8.45439348104948
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3274 - 3274
+gpbeam = 8.454162313200131
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3275 - 3275
+gpbeam = 8.454597458346436
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3276 - 3276
+gpbeam = 8.45698579954235
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3277 - 3277
+gpbeam = 8.457031539684353
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3278 - 3278
+gpbeam = 8.457162648383802
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3279 - 3279
+gpbeam = 8.457320522039398
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3280 - 3280
+gpbeam = 8.457289495810135
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3281 - 3281
+gpbeam = 8.455267946921179
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3282 - 3282
+gpbeam = 8.457279854235141
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3283 - 3283
+gpbeam = 8.457190015374058
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3284 - 3284
+gpbeam = 8.457226754537206
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3285 - 3285
+gpbeam = 8.457284993191
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3286 - 3286
+gpbeam = 8.457131195002749
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3287 - 3287
+gpbeam = 8.457060829506522
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3288 - 3288
+gpbeam = 8.457158234280998
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3289 - 3289
+gpbeam = 8.456987313717562
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3290 - 3290
+gpbeam = 8.457024650046865
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3291 - 3291
+gpbeam = 8.457189107942089
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3292 - 3292
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3293 - 3293
+gpbeam = 8.457039160800456
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3294 - 3294
+gpbeam = 8.457250551081913
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3295 - 3295
+gpbeam = 8.456942005595765
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3296 - 3296
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3297 - 3297
+gpbeam = 8.457133738517715
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3298 - 3298
+gpbeam = 8.456960636618795
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3299 - 3299
+gpbeam = 8.457102282924541
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3300 - 3300
+gpbeam = 8.45686847186682
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3301 - 3301
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3302 - 3302
+gpbeam = 8.456619426734644
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3303 - 3303
+gpbeam = 8.456665001884222
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3304 - 3304
+gpbeam = 8.45682898942351
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3305 - 3305
+gpbeam = 8.456714054001704
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3306 - 3306
+gpbeam = 8.456655843156598
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3307 - 3307
+gpbeam = 8.456934232296282
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3308 - 3308
+gpbeam = 8.456862269013246
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3309 - 3309
+gpbeam = 8.456741712470814
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3310 - 3310
+gpbeam = 8.456920546267417
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3311 - 3311
+gpbeam = 8.456890932984466
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3312 - 3312
+gpbeam = 8.456727561460948
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3313 - 3313
+gpbeam = 8.456612524874798
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3314 - 3314
+gpbeam = 8.45699892480455
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3315 - 3315
+gpbeam = 8.456846269997232
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3316 - 3316
+gpbeam = 8.456631781974965
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3317 - 3317
+gpbeam = 8.456797722135866
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3318 - 3318
+gpbeam = 8.456855293816156
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3319 - 3319
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3320 - 3320
+gpbeam = 8.45658442738714
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3321 - 3321
+gpbeam = 8.456789234549722
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3322 - 3322
+gpbeam = 8.4564503670724
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3323 - 3323
+gpbeam = 8.455979265903697
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3324 - 3324
+gpbeam = 8.456060554993252
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3325 - 3325
+gpbeam = 8.456368185495519
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3326 - 3326
+gpbeam = 8.45646504899274
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3327 - 3327
+gpbeam = 8.456216608460162
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3328 - 3328
+gpbeam = 8.456242106006364
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3329 - 3329
+gpbeam = 8.456468265482249
+gtargmass_amu = 26.981539
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3330 - 3330
+gpbeam = 8.457894704697138
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3331 - 3331
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3332 - 3332
+gpbeam = 8.456727784469987
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3333 - 3333
+gpbeam = 8.456466176225428
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3334 - 3334
+gpbeam = 8.456363342910063
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3335 - 3335
+gpbeam = 8.456406547051845
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3336 - 3336
+gpbeam = 8.456242738526639
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3337 - 3337
+gpbeam = 8.455751164080258
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3338 - 3338
+gpbeam = 8.45581973709748
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3339 - 3339
+gpbeam = 8.455760051721708
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3340 - 3340
+gpbeam = 8.455755908935517
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3341 - 3341
+gpbeam = 8.455350296924207
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3342 - 3342
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3343 - 3343
+gpbeam = 8.457894704697138
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3344 - 3344
+gpbeam = 8.455372870378863
+gtargmass_amu = 0.0
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3345 - 3345
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3346 - 3346
+gpbeam = 8.457894704697138
+gtargmass_amu = 0.0
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3347 - 3347
+gpbeam = 8.455633948887655
+gtargmass_amu = 0.0
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3348 - 3348
+gpbeam = 8.45788060552827
+gtargmass_amu = 0.0
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3349 - 3349
+gpbeam = 8.45788060552827
+gtargmass_amu = 0.0
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3350 - 3350
+gpbeam = 8.455300298015084
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3351 - 3351
+gpbeam = 8.455583072445753
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3352 - 3352
+gpbeam = 8.455489456701724
+gtargmass_amu = 2.014101778
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 33.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3353 - 3353
+gpbeam = 8.455196945045925
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3354 - 3354
+gpbeam = 8.455086600304545
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3355 - 3355
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3356 - 3356
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -16.75
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3357 - 3357
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.726
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3358 - 3358
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.726
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3359 - 3359
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.726
+stheta_lab = 36.14
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3360 - 3360
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -27.62
+hpcentral = 4.726
+stheta_lab = 36.15
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3361 - 3361
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3362 - 3362
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3363 - 3363
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3364 - 3364
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3365 - 3365
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 4.726
+stheta_lab = 35.28
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3366 - 3366
+gpbeam = 8.45788060552827
+gtargmass_amu = 0.0
+htheta_lab = -22.93
+hpcentral = 3.803
+stheta_lab = 32.85
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3367 - 3367
+gpbeam = 8.454343302803544
+gtargmass_amu = 12.0107
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3368 - 3368
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3369 - 3369
+gpbeam = 8.454300504474936
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3370 - 3370
+gpbeam = 8.454421382900804
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3371 - 3371
+gpbeam = 8.45445543350919
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3372 - 3372
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3373 - 3373
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3374 - 3374
+gpbeam = 8.4543210051085
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3375 - 3375
+gpbeam = 8.45436865292597
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3376 - 3376
+gpbeam = 8.45439969648235
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3377 - 3377
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3378 - 3378
+gpbeam = 8.454287230480231
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3379 - 3379
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3380 - 3380
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3381 - 3381
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3382 - 3382
+gpbeam = 8.453520806919839
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3383 - 3383
+gpbeam = 8.45397952500586
+gtargmass_amu = 0.0
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3384 - 3384
+gpbeam = 8.454363467834156
+gtargmass_amu = 0.0
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3385 - 3385
+gpbeam = 8.45788060552827
+gtargmass_amu = 0.0
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 36.300000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3386 - 3386
+gpbeam = 8.454182757105803
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3387 - 3387
+gpbeam = 8.454063273519541
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3388 - 3388
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3389 - 3389
+gpbeam = 8.45406375838332
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3390 - 3390
+gpbeam = 8.453951619221641
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3391 - 3391
+gpbeam = 8.454218849048498
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3392 - 3392
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3393 - 3393
+gpbeam = 8.454139681448437
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3394 - 3394
+gpbeam = 8.454075729388633
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3395 - 3395
+gpbeam = 8.453820233918867
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3396 - 3396
+gpbeam = 8.453880457060963
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3397 - 3397
+gpbeam = 8.453734983921573
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3398 - 3398
+gpbeam = 8.453501586047732
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3399 - 3399
+gpbeam = 8.453490520276434
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3400 - 3400
+gpbeam = 8.453440789973428
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3401 - 3401
+gpbeam = 8.453186321781354
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3402 - 3402
+gpbeam = 8.45353208350876
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3403 - 3403
+gpbeam = 8.453572185730186
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3404 - 3404
+gpbeam = 8.453421537417201
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3405 - 3405
+gpbeam = 8.453515127350332
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3406 - 3406
+gpbeam = 8.453168023675348
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3407 - 3407
+gpbeam = 8.453362726723286
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3408 - 3408
+gpbeam = 8.453465990399971
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3409 - 3409
+gpbeam = 8.453416145362878
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3410 - 3410
+gpbeam = 8.453372483563728
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3411 - 3411
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3412 - 3412
+gpbeam = 8.453574254502751
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3413 - 3413
+gpbeam = 8.453862339028138
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3414 - 3414
+gpbeam = 8.453522863889217
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3415 - 3415
+gpbeam = 8.453447987161105
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3416 - 3416
+gpbeam = 8.453755670099877
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3417 - 3417
+gpbeam = 8.455128686336652
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3418 - 3418
+gpbeam = 8.454969674034016
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3419 - 3419
+gpbeam = 8.45479621611487
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3420 - 3420
+gpbeam = 8.454488291194151
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3421 - 3421
+gpbeam = 8.454988447801703
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3422 - 3422
+gpbeam = 8.454758954133835
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3423 - 3423
+gpbeam = 8.454878911210367
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3424 - 3424
+gpbeam = 8.45472894222966
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3425 - 3425
+gpbeam = 8.45506934912397
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3426 - 3426
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3427 - 3427
+gpbeam = 8.454940359202068
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3428 - 3428
+gpbeam = 8.455047013644121
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3429 - 3429
+gpbeam = 8.454798683633772
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3430 - 3430
+gpbeam = 8.455085968293371
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3431 - 3431
+gpbeam = 8.454898263415188
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3432 - 3432
+gpbeam = 8.454601419036509
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3433 - 3433
+gpbeam = 8.454622189217284
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3434 - 3434
+gpbeam = 8.454158198920252
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3435 - 3435
+gpbeam = 8.454788782656637
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3436 - 3436
+gpbeam = 8.454839542788442
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3437 - 3437
+gpbeam = 8.454791196006077
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3438 - 3438
+gpbeam = 8.454787140351415
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3439 - 3439
+gpbeam = 8.455134457240414
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3440 - 3440
+gpbeam = 8.455042888193383
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3441 - 3441
+gpbeam = 8.455111650579067
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3442 - 3442
+gpbeam = 8.454926714185355
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3443 - 3443
+gpbeam = 8.454936909874947
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3444 - 3444
+gpbeam = 8.45501073980216
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3445 - 3445
+gpbeam = 8.454982282701353
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3446 - 3446
+gpbeam = 8.454822728329315
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3447 - 3447
+gpbeam = 8.45473332964939
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3448 - 3448
+gpbeam = 8.454935948113203
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3449 - 3449
+gpbeam = 8.45502919772494
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3450 - 3450
+gpbeam = 8.454630268437024
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3451 - 3451
+gpbeam = 8.454710796625644
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3452 - 3452
+gpbeam = 8.454425599625827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3453 - 3453
+gpbeam = 8.45465478902488
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3454 - 3454
+gpbeam = 8.454606930774492
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3455 - 3455
+gpbeam = 8.454948245628541
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3456 - 3456
+gpbeam = 8.454934788856423
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3457 - 3457
+gpbeam = 8.454920249241136
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3458 - 3458
+gpbeam = 8.454970872387094
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3459 - 3459
+gpbeam = 8.454876891598651
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3460 - 3460
+gpbeam = 8.455038594985437
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3461 - 3461
+gpbeam = 8.455010015069094
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3462 - 3462
+gpbeam = 8.455112058966385
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3463 - 3463
+gpbeam = 8.454898184254354
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3464 - 3464
+gpbeam = 8.45500364526738
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3465 - 3465
+gpbeam = 8.45497190528728
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3466 - 3466
+gpbeam = 8.455022288742072
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3467 - 3467
+gpbeam = 8.454768426637589
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3468 - 3468
+gpbeam = 8.454926092384083
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3469 - 3469
+gpbeam = 8.454669776455871
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3470 - 3470
+gpbeam = 8.454842435205812
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3471 - 3471
+gpbeam = 8.45474800788108
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3472 - 3472
+gpbeam = 8.455036401707222
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3473 - 3473
+gpbeam = 8.455004488900961
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3474 - 3474
+gpbeam = 8.454759306945203
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3475 - 3475
+gpbeam = 8.45499685016694
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3476 - 3476
+gpbeam = 8.45486808014738
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3477 - 3477
+gpbeam = 8.45507128016922
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3478 - 3478
+gpbeam = 8.454655033762002
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3479 - 3479
+gpbeam = 8.454663737026609
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3480 - 3480
+gpbeam = 8.454813000835896
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3481 - 3481
+gpbeam = 8.454973191240594
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3482 - 3482
+gpbeam = 8.454852183340684
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3483 - 3483
+gpbeam = 8.454646368504267
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3484 - 3484
+gpbeam = 8.454491955890767
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3485 - 3485
+gpbeam = 8.455045141563817
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3486 - 3486
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3487 - 3487
+gpbeam = 8.45788060552827
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3488 - 3488
+gpbeam = 8.45491957154295
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3489 - 3489
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3490 - 3490
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3491 - 3491
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3492 - 3492
+gpbeam = 8.454565128604475
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3493 - 3493
+gpbeam = 8.454680068858094
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3494 - 3494
+gpbeam = 8.45496658814715
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3495 - 3495
+gpbeam = 8.454876129238668
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3496 - 3496
+gpbeam = 8.454984572328593
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3497 - 3497
+gpbeam = 8.4549282912516
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3498 - 3498
+gpbeam = 8.454918951613303
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3499 - 3499
+gpbeam = 8.454773208586673
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3500 - 3500
+gpbeam = 8.454850011177859
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3501 - 3501
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3502 - 3502
+gpbeam = 8.454708925458938
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3503 - 3503
+gpbeam = 8.454663887095723
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3504 - 3504
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3505 - 3505
+gpbeam = 8.454599245290954
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3506 - 3506
+gpbeam = 8.454732250004048
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3507 - 3507
+gpbeam = 8.454523646848235
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3508 - 3508
+gpbeam = 8.454690635900628
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3509 - 3509
+gpbeam = 8.454857628756619
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3510 - 3510
+gpbeam = 8.454508464034202
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3511 - 3511
+gpbeam = 8.454645142326525
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3512 - 3512
+gpbeam = 8.45454500134131
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3513 - 3513
+gpbeam = 8.45461431250447
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3514 - 3514
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3515 - 3515
+gpbeam = 8.454678442843912
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3516 - 3516
+gpbeam = 8.454449831033218
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3517 - 3517
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3518 - 3518
+gpbeam = 8.454591733279928
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3519 - 3519
+gpbeam = 8.45446150437025
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3520 - 3520
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3521 - 3521
+gpbeam = 8.454459601481823
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3522 - 3522
+gpbeam = 8.454036002617826
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3523 - 3523
+gpbeam = 8.453806896956067
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3524 - 3524
+gpbeam = 8.454018607623684
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3525 - 3525
+gpbeam = 8.453994266655643
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3526 - 3526
+gpbeam = 8.453862810689143
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3527 - 3527
+gpbeam = 8.454540524618901
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3528 - 3528
+gpbeam = 8.454557752384105
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3529 - 3529
+gpbeam = 8.454863841571706
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3530 - 3530
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3531 - 3531
+gpbeam = 8.454551906538414
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3532 - 3532
+gpbeam = 8.45464262043677
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3533 - 3533
+gpbeam = 8.454663944493657
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3534 - 3534
+gpbeam = 8.454610784004371
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3535 - 3535
+gpbeam = 8.454693584775804
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3536 - 3536
+gpbeam = 8.454809901562415
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3537 - 3537
+gpbeam = 8.45471302952185
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3538 - 3538
+gpbeam = 8.454730617390428
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3539 - 3539
+gpbeam = 8.454754096186111
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3540 - 3540
+gpbeam = 8.454766626760051
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3541 - 3541
+gpbeam = 8.454689856114914
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3542 - 3542
+gpbeam = 8.45497036370628
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3543 - 3543
+gpbeam = 8.454836784137894
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3544 - 3544
+gpbeam = 8.45494896374112
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3545 - 3545
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3546 - 3546
+gpbeam = 8.455057763722888
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3547 - 3547
+gpbeam = 8.454875006336014
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3548 - 3548
+gpbeam = 8.454635391116094
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3549 - 3549
+gpbeam = 8.454894719592524
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3550 - 3550
+gpbeam = 8.454750779413509
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3551 - 3551
+gpbeam = 8.45473257007212
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3552 - 3552
+gpbeam = 8.454641879930026
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3553 - 3553
+gpbeam = 8.454582393016107
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3554 - 3554
+gpbeam = 8.45500189977382
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3555 - 3555
+gpbeam = 8.454790202862176
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3556 - 3556
+gpbeam = 8.455053442843964
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3557 - 3557
+gpbeam = 8.454932857122625
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3558 - 3558
+gpbeam = 8.454977820936694
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3559 - 3559
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3560 - 3560
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3561 - 3561
+gpbeam = 8.454992579709007
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3562 - 3562
+gpbeam = 8.455191797809087
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3563 - 3563
+gpbeam = 8.454797893517528
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3564 - 3564
+gpbeam = 8.45485173912944
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3565 - 3565
+gpbeam = 8.454751908212879
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3566 - 3566
+gpbeam = 8.454890942497178
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3567 - 3567
+gpbeam = 8.454310846216947
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3568 - 3568
+gpbeam = 8.454625210469747
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3569 - 3569
+gpbeam = 8.45473977373133
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3570 - 3570
+gpbeam = 8.454625659476637
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3571 - 3571
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3572 - 3572
+gpbeam = 8.454105694164593
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3573 - 3573
+gpbeam = 8.454573435002866
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3574 - 3574
+gpbeam = 8.454071051025586
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3575 - 3575
+gpbeam = 8.454069129454862
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3576 - 3576
+gpbeam = 8.45372610237343
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3577 - 3577
+gpbeam = 8.453867622467408
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3578 - 3578
+gpbeam = 8.453526771545693
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3579 - 3579
+gpbeam = 8.453575926988517
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3580 - 3580
+gpbeam = 8.453462745498621
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3581 - 3581
+gpbeam = 8.453402080675389
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3582 - 3582
+gpbeam = 8.453350280378062
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3583 - 3583
+gpbeam = 8.453573956403995
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3584 - 3584
+gpbeam = 8.453392416895577
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3585 - 3585
+gpbeam = 8.453200985896794
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3586 - 3586
+gpbeam = 8.453115659608399
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3587 - 3587
+gpbeam = 8.45788060552827
+gtargmass_amu = 0.0
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3588 - 3588
+gpbeam = 8.45788060552827
+gtargmass_amu = 0.0
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3589 - 3589
+gpbeam = 8.45371040282665
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3590 - 3590
+gpbeam = 8.453475584179376
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3591 - 3591
+gpbeam = 8.452957853057658
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3592 - 3592
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3593 - 3593
+gpbeam = 8.45327831902516
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3594 - 3594
+gpbeam = 8.45788060552827
+gtargmass_amu = 0.0
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3595 - 3595
+gpbeam = 8.453123870500558
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3596 - 3596
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3597 - 3597
+gpbeam = 8.45321062078263
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3598 - 3598
+gpbeam = 8.453184732829893
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3599 - 3599
+gpbeam = 8.453586542709683
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3600 - 3600
+gpbeam = 8.453350388862885
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3601 - 3601
+gpbeam = 8.453239294015846
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3602 - 3602
+gpbeam = 8.453322900427253
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3603 - 3603
+gpbeam = 8.453045013627316
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3604 - 3604
+gpbeam = 8.453327278676772
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3605 - 3605
+gpbeam = 8.454224016493828
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3606 - 3606
+gpbeam = 8.45421166086388
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3607 - 3607
+gpbeam = 8.454000639698803
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3608 - 3608
+gpbeam = 8.453687631955283
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3609 - 3609
+gpbeam = 8.453826535496036
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3610 - 3610
+gpbeam = 8.45382319402973
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3611 - 3611
+gpbeam = 8.453780694463907
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3612 - 3612
+gpbeam = 8.453556494259189
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3613 - 3613
+gpbeam = 8.45355632147386
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3614 - 3614
+gpbeam = 8.45315138713869
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3615 - 3615
+gpbeam = 8.453049639805998
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3616 - 3616
+gpbeam = 8.454830447890503
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3617 - 3617
+gpbeam = 8.455044457211537
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3618 - 3618
+gpbeam = 8.454861457405439
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3619 - 3619
+gpbeam = 8.454955133896812
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3620 - 3620
+gpbeam = 8.455050750966533
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.77
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3621 - 3621
+gpbeam = 8.454869202040872
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3622 - 3622
+gpbeam = 8.454655145981327
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3623 - 3623
+gpbeam = 8.454770028902479
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3624 - 3624
+gpbeam = 8.45502263998461
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3625 - 3625
+gpbeam = 8.454925916726092
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3626 - 3626
+gpbeam = 8.455089947526305
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3627 - 3627
+gpbeam = 8.454802000348458
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3628 - 3628
+gpbeam = 8.455166518984038
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3629 - 3629
+gpbeam = 8.455004634374538
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3630 - 3630
+gpbeam = 8.458190012556093
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3631 - 3631
+gpbeam = 8.455077882895019
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3632 - 3632
+gpbeam = 8.45788060552827
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3633 - 3633
+gpbeam = 8.45509093584992
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3634 - 3634
+gpbeam = 8.455120140523526
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3635 - 3635
+gpbeam = 8.454883982381068
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3636 - 3636
+gpbeam = 8.455276941761054
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3637 - 3637
+gpbeam = 8.454979205332867
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3638 - 3638
+gpbeam = 8.454803909494307
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3639 - 3639
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3640 - 3640
+gpbeam = 8.455121534378222
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3641 - 3641
+gpbeam = 8.455078112329712
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3642 - 3642
+gpbeam = 8.455086632751224
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3643 - 3643
+gpbeam = 8.454778653864809
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3644 - 3644
+gpbeam = 8.45788060552827
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3645 - 3645
+gpbeam = 8.45465575751895
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3646 - 3646
+gpbeam = 8.45429655696705
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3647 - 3647
+gpbeam = 8.454775554570293
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3648 - 3648
+gpbeam = 8.455134939850954
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3649 - 3649
+gpbeam = 8.455134939850954
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3650 - 3650
+gpbeam = 8.45497125018809
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3651 - 3651
+gpbeam = 8.454966191129515
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3652 - 3652
+gpbeam = 8.45514623670993
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3653 - 3653
+gpbeam = 8.455142018961164
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3654 - 3654
+gpbeam = 8.455079143883598
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3655 - 3655
+gpbeam = 8.455189121911832
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 28.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3656 - 3656
+gpbeam = 8.455012397614938
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.87
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3657 - 3657
+gpbeam = 8.45788060552827
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3658 - 3658
+gpbeam = 8.454739826683278
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3659 - 3659
+gpbeam = 8.454853218690973
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3660 - 3660
+gpbeam = 8.45488091480624
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3661 - 3661
+gpbeam = 8.454899801649006
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3662 - 3662
+gpbeam = 8.454940864757933
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3663 - 3663
+gpbeam = 8.454793338196094
+gtargmass_amu = 1.007825032
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3664 - 3664
+gpbeam = 8.454764604841449
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3665 - 3665
+gpbeam = 8.454842894612172
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3666 - 3666
+gpbeam = 8.454732178221093
+gtargmass_amu = 26.981539
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3667 - 3667
+gpbeam = 8.454843501960518
+gtargmass_amu = 2.014101778
+htheta_lab = -22.92
+hpcentral = 3.803
+stheta_lab = 32.89
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3668 - 3668
+gpbeam = 8.45788060552827
+gtargmass_amu = 0.0
+htheta_lab = -22.92
+hpcentral = 0.0
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3669 - 3669
+gpbeam = 8.45788060552827
+gtargmass_amu = 0.0
+htheta_lab = -22.92
+hpcentral = 0.0
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3670 - 3670
+gpbeam = 8.45788060552827
+gtargmass_amu = 0.0
+htheta_lab = -22.92
+hpcentral = 0.0
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3671 - 3671
+gpbeam = 8.45788060552827
+gtargmass_amu = 0.0
+htheta_lab = -22.92
+hpcentral = 0.0
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3672 - 3672
+gpbeam = 8.45788060552827
+gtargmass_amu = 0.0
+htheta_lab = -22.92
+hpcentral = 0.0
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3673 - 3673
+gpbeam = 8.45788060552827
+gtargmass_amu = 0.0
+htheta_lab = -22.92
+hpcentral = 0.0
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3674 - 3674
+gpbeam = 8.45788060552827
+gtargmass_amu = 0.0
+htheta_lab = -22.92
+hpcentral = 0.0
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3717 - 3717
+gpbeam = 10.538709464198682
+gtargmass_amu = 12.0107
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3718 - 3718
+gpbeam = 10.538709464198682
+gtargmass_amu = 12.0107
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3719 - 3719
+gpbeam = 10.538709464198682
+gtargmass_amu = 12.0107
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3720 - 3720
+gpbeam = 10.538709464198682
+gtargmass_amu = 12.0107
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+3721 - 3721
+gpbeam = 10.539515130991152
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3722 - 3722
+gpbeam = 10.539515130991152
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3723 - 3723
+gpbeam = 10.539515130991152
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3724 - 3724
+gpbeam = 10.538087783396824
+gtargmass_amu = 12.0107
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3725 - 3725
+gpbeam = 10.538367210152424
+gtargmass_amu = 12.0107
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3726 - 3726
+gpbeam = 10.538471740544248
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3727 - 3727
+gpbeam = 10.538417139724588
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3728 - 3728
+gpbeam = 10.538141655516272
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3729 - 3729
+gpbeam = 10.538124844270053
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3730 - 3730
+gpbeam = 10.539515130991152
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3731 - 3731
+gpbeam = 10.538237248360257
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3732 - 3732
+gpbeam = 10.538193448793201
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3733 - 3733
+gpbeam = 10.53842921527074
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3734 - 3734
+gpbeam = 10.539515130991152
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3735 - 3735
+gpbeam = 10.53841981418288
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3736 - 3736
+gpbeam = 10.538403416193104
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3737 - 3737
+gpbeam = 10.538366244674386
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3738 - 3738
+gpbeam = 10.539515130991152
+gtargmass_amu = 26.981539
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3739 - 3739
+gpbeam = 10.538149643433142
+gtargmass_amu = 26.981539
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3740 - 3740
+gpbeam = 10.538427273915856
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3741 - 3741
+gpbeam = 10.538493771900466
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3742 - 3742
+gpbeam = 10.538510465624018
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3743 - 3743
+gpbeam = 10.53818106176333
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3744 - 3744
+gpbeam = 10.538389326941946
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3745 - 3745
+gpbeam = 10.538434893037945
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3746 - 3746
+gpbeam = 10.538368884792806
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3747 - 3747
+gpbeam = 10.538304425300426
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3748 - 3748
+gpbeam = 10.53789555782354
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3749 - 3749
+gpbeam = 10.538130371992565
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3750 - 3750
+gpbeam = 10.537872303063173
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3751 - 3751
+gpbeam = 10.53815045313819
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3752 - 3752
+gpbeam = 10.538018093785954
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3753 - 3753
+gpbeam = 10.537842154682556
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3754 - 3754
+gpbeam = 10.537954317543178
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3755 - 3755
+gpbeam = 10.539515130991152
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3756 - 3756
+gpbeam = 10.53752218233502
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3757 - 3757
+gpbeam = 10.53682156204708
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3758 - 3758
+gpbeam = 10.537512681448224
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3759 - 3759
+gpbeam = 10.539515130991152
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3760 - 3760
+gpbeam = 10.538177033588335
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3761 - 3761
+gpbeam = 10.539515130991152
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3762 - 3762
+gpbeam = 10.539515130991152
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3763 - 3763
+gpbeam = 10.538273548428272
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3764 - 3764
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3765 - 3765
+gpbeam = 10.53805329049904
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3766 - 3766
+gpbeam = 10.537877011279324
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3767 - 3767
+gpbeam = 10.537907004087238
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3768 - 3768
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3769 - 3769
+gpbeam = 10.53765257521191
+gtargmass_amu = 26.981539
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3770 - 3770
+gpbeam = 10.537891242189463
+gtargmass_amu = 26.981539
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3771 - 3771
+gpbeam = 10.53832146767124
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3772 - 3772
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3773 - 3773
+gpbeam = 10.538530897080953
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3774 - 3774
+gpbeam = 10.538255415961958
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3775 - 3775
+gpbeam = 10.538261609928238
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3776 - 3776
+gpbeam = 10.53829545679573
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3777 - 3777
+gpbeam = 10.538446970850258
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3778 - 3778
+gpbeam = 10.538394004053089
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3779 - 3779
+gpbeam = 10.538179516798698
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3780 - 3780
+gpbeam = 10.53837705279812
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3781 - 3781
+gpbeam = 10.538202730389322
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3782 - 3782
+gpbeam = 10.538274321058836
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 28.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3783 - 3783
+gpbeam = 10.537825061774631
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3784 - 3784
+gpbeam = 10.538344144758819
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3785 - 3785
+gpbeam = 10.537799733199133
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3786 - 3786
+gpbeam = 10.53765670323953
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3787 - 3787
+gpbeam = 10.537908823244276
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3788 - 3788
+gpbeam = 10.537695286905569
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3789 - 3789
+gpbeam = 10.537588092369571
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3790 - 3790
+gpbeam = 10.537686290006643
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3791 - 3791
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3792 - 3792
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3793 - 3793
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3794 - 3794
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3795 - 3795
+gpbeam = 10.538209372305845
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3796 - 3796
+gpbeam = 10.538371812134079
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3797 - 3797
+gpbeam = 10.538240406397417
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3798 - 3798
+gpbeam = 10.538379539230643
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3799 - 3799
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3800 - 3800
+gpbeam = 10.538302490609663
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3801 - 3801
+gpbeam = 10.538324844337035
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3802 - 3802
+gpbeam = 10.5383861500334
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3803 - 3803
+gpbeam = 10.538249170525042
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3804 - 3804
+gpbeam = 10.538410008221756
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3805 - 3805
+gpbeam = 10.538290194422618
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3806 - 3806
+gpbeam = 10.538315858146516
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3807 - 3807
+gpbeam = 10.53784103163606
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3808 - 3808
+gpbeam = 10.537839699372748
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3809 - 3809
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3810 - 3810
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3811 - 3811
+gpbeam = 10.53795143922144
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3812 - 3812
+gpbeam = 10.538187618430637
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3813 - 3813
+gpbeam = 10.538525095839484
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3814 - 3814
+gpbeam = 10.53800713476017
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3815 - 3815
+gpbeam = 10.538180092986881
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3816 - 3816
+gpbeam = 10.538144457509715
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3817 - 3817
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3818 - 3818
+gpbeam = 10.53796128937305
+gtargmass_amu = 26.981539
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3819 - 3819
+gpbeam = 10.538390360233615
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3820 - 3820
+gpbeam = 10.538505998466546
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3821 - 3821
+gpbeam = 10.538910880896797
+gtargmass_amu = 0.0
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3822 - 3822
+gpbeam = 10.538449368882372
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3823 - 3823
+gpbeam = 10.537960576043291
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3824 - 3824
+gpbeam = 10.538334262141559
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3825 - 3825
+gpbeam = 10.53807020710516
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3826 - 3826
+gpbeam = 10.537975958944319
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3827 - 3827
+gpbeam = 10.537921472063294
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3828 - 3828
+gpbeam = 10.538162487102475
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3829 - 3829
+gpbeam = 10.538910880896797
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3830 - 3830
+gpbeam = 10.538531101852739
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3831 - 3831
+gpbeam = 10.538196650235706
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3832 - 3832
+gpbeam = 10.538452720212641
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3833 - 3833
+gpbeam = 10.540010348691427
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3834 - 3834
+gpbeam = 10.538341138502933
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3835 - 3835
+gpbeam = 10.538910880896797
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3836 - 3836
+gpbeam = 10.538176531295086
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3837 - 3837
+gpbeam = 10.538635466945037
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3838 - 3838
+gpbeam = 10.538225123078021
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3839 - 3839
+gpbeam = 10.538144796581078
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3840 - 3840
+gpbeam = 10.538624602656109
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3841 - 3841
+gpbeam = 10.538185670000317
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3842 - 3842
+gpbeam = 10.53826279797539
+gtargmass_amu = 26.981539
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3843 - 3843
+gpbeam = 10.538392467946846
+gtargmass_amu = 26.981539
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3844 - 3844
+gpbeam = 10.538657217708518
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3845 - 3845
+gpbeam = 10.538910880896797
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3846 - 3846
+gpbeam = 10.538910880896797
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3847 - 3847
+gpbeam = 10.537850491070303
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3848 - 3848
+gpbeam = 10.537753343823795
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3849 - 3849
+gpbeam = 10.537690298100692
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3850 - 3850
+gpbeam = 10.537963395296144
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3851 - 3851
+gpbeam = 10.537836927410996
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3852 - 3852
+gpbeam = 10.537610879251618
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3853 - 3853
+gpbeam = 10.537804991531535
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3854 - 3854
+gpbeam = 10.53788847796266
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3855 - 3855
+gpbeam = 10.53909300271685
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3856 - 3856
+gpbeam = 10.539118310543763
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3857 - 3857
+gpbeam = 10.538910880896797
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 35.44
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3858 - 3858
+gpbeam = 10.538910880896797
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3859 - 3859
+gpbeam = 10.538625174158907
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3860 - 3860
+gpbeam = 10.538799644227712
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3861 - 3861
+gpbeam = 10.53897427677332
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3862 - 3862
+gpbeam = 10.535666849437542
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3863 - 3863
+gpbeam = 10.539212142939643
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3864 - 3864
+gpbeam = 10.53917994327032
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3865 - 3865
+gpbeam = 10.539196950590066
+gtargmass_amu = 1.007825032
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3866 - 3866
+gpbeam = 10.538532987172562
+gtargmass_amu = 26.981539
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3867 - 3867
+gpbeam = 10.538324687232747
+gtargmass_amu = 26.981539
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3868 - 3868
+gpbeam = 10.539093291354149
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3869 - 3869
+gpbeam = 10.538469121829438
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3870 - 3870
+gpbeam = 10.538453333768517
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3871 - 3871
+gpbeam = 10.538384331359902
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3872 - 3872
+gpbeam = 10.538910880896797
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3873 - 3873
+gpbeam = 10.538910880896797
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3874 - 3874
+gpbeam = 10.538910880896797
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3875 - 3875
+gpbeam = 10.537388829598548
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3876 - 3876
+gpbeam = 10.537612857650556
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3877 - 3877
+gpbeam = 10.537329798673108
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3878 - 3878
+gpbeam = 10.537293367307937
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3879 - 3879
+gpbeam = 10.537667417827592
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3880 - 3880
+gpbeam = 10.537502204218342
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3881 - 3881
+gpbeam = 10.537307573031649
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3882 - 3882
+gpbeam = 10.537240588814951
+gtargmass_amu = 2.014101778
+htheta_lab = -12.48
+hpcentral = 6.667
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3883 - 3883
+gpbeam = 10.538910880896797
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 32.88
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3884 - 3884
+gpbeam = 10.539167817044161
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3885 - 3885
+gpbeam = 10.53913359538123
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 31.060000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3886 - 3886
+gpbeam = 10.539064369643299
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 33.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3887 - 3887
+gpbeam = 10.539098256164843
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3888 - 3888
+gpbeam = 10.539113254616808
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 31.060000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3889 - 3889
+gpbeam = 10.538910880896797
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 33.480000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3890 - 3890
+gpbeam = 10.539115402153499
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3891 - 3891
+gpbeam = 10.539100697624269
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3892 - 3892
+gpbeam = 10.539099812155326
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 31.060000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3893 - 3893
+gpbeam = 10.53910544343518
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 33.480000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3894 - 3894
+gpbeam = 10.539056875592987
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 33.480000000000004
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3895 - 3895
+gpbeam = 10.539186189328207
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3896 - 3896
+gpbeam = 10.539127696714353
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 32.27
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3897 - 3897
+gpbeam = 10.539141611118541
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 31.05
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3898 - 3898
+gpbeam = 10.539148502740774
+gtargmass_amu = 1.007825032
+htheta_lab = -29.85
+hpcentral = 4.0782
+stheta_lab = 31.05
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+3899 - 3899
+gpbeam = 10.539219227888186
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3900 - 3900
+gpbeam = 10.538910880896797
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3901 - 3901
+gpbeam = 10.539166904734273
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3902 - 3902
+gpbeam = 10.538910880896797
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3903 - 3903
+gpbeam = 10.53749865167855
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3904 - 3904
+gpbeam = 10.537393864282128
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3905 - 3905
+gpbeam = 10.537479623584142
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3906 - 3906
+gpbeam = 10.537395033528423
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3907 - 3907
+gpbeam = 10.538910880896797
+gtargmass_amu = 0.0
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3908 - 3908
+gpbeam = 10.537006902488363
+gtargmass_amu = 26.981539
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3909 - 3909
+gpbeam = 10.538910880896797
+gtargmass_amu = 26.981539
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3910 - 3910
+gpbeam = 10.53736128835718
+gtargmass_amu = 26.981539
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3911 - 3911
+gpbeam = 10.537336765490961
+gtargmass_amu = 26.981539
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3912 - 3912
+gpbeam = 10.537265868011387
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3913 - 3913
+gpbeam = 10.538910880896797
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3914 - 3914
+gpbeam = 10.537088284349412
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3915 - 3915
+gpbeam = 10.536451041370778
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3916 - 3916
+gpbeam = 10.536682558389769
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3917 - 3917
+gpbeam = 10.5375107008092
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3918 - 3918
+gpbeam = 10.537363419731006
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3919 - 3919
+gpbeam = 10.537407015983431
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3920 - 3920
+gpbeam = 10.537234556852518
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3921 - 3921
+gpbeam = 10.537418116157145
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3922 - 3922
+gpbeam = 10.537414828451496
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3923 - 3923
+gpbeam = 10.53712973279
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3924 - 3924
+gpbeam = 10.537353963439815
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3925 - 3925
+gpbeam = 10.537321628633567
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3926 - 3926
+gpbeam = 10.537345653003737
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3927 - 3927
+gpbeam = 10.537459408880796
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3928 - 3928
+gpbeam = 10.537336167822854
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3929 - 3929
+gpbeam = 10.536925882013104
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3930 - 3930
+gpbeam = 10.537290113540427
+gtargmass_amu = 26.981539
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3931 - 3931
+gpbeam = 10.537315155588592
+gtargmass_amu = 26.981539
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3932 - 3932
+gpbeam = 10.538910880896797
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3933 - 3933
+gpbeam = 10.538910880896797
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3934 - 3934
+gpbeam = 10.537725391145603
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3935 - 3935
+gpbeam = 10.537520128124902
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3936 - 3936
+gpbeam = 10.537447909982879
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3937 - 3937
+gpbeam = 10.53744009513422
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3938 - 3938
+gpbeam = 10.537438714925818
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3939 - 3939
+gpbeam = 10.537710474024646
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3940 - 3940
+gpbeam = 10.537444513892229
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3941 - 3941
+gpbeam = 10.537434427351435
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3942 - 3942
+gpbeam = 10.537325838834413
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3943 - 3943
+gpbeam = 10.537304609374736
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 29.73
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3944 - 3944
+gpbeam = 10.536657332484005
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3945 - 3945
+gpbeam = 10.537271400447958
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3946 - 3946
+gpbeam = 10.537305751454552
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3947 - 3947
+gpbeam = 10.537586206264544
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3948 - 3948
+gpbeam = 10.537197889918223
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3949 - 3949
+gpbeam = 10.53681198348438
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3950 - 3950
+gpbeam = 10.536812865870713
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3951 - 3951
+gpbeam = 10.537191001593667
+gtargmass_amu = 26.981539
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3952 - 3952
+gpbeam = 10.537278501237957
+gtargmass_amu = 26.981539
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3953 - 3953
+gpbeam = 10.53738622394371
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3954 - 3954
+gpbeam = 10.537424766722262
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3955 - 3955
+gpbeam = 10.537292820387941
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3956 - 3956
+gpbeam = 10.537167197885891
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3957 - 3957
+gpbeam = 10.537407433266761
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3958 - 3958
+gpbeam = 10.537055640609054
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3959 - 3959
+gpbeam = 10.537403929565905
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3960 - 3960
+gpbeam = 10.537418487025569
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3961 - 3961
+gpbeam = 10.537374877464238
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3962 - 3962
+gpbeam = 10.53750206607807
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3963 - 3963
+gpbeam = 10.537340223749682
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3964 - 3964
+gpbeam = 10.537166386835937
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3965 - 3965
+gpbeam = 10.537074464996746
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3966 - 3966
+gpbeam = 10.53721534865124
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3967 - 3967
+gpbeam = 10.537603428444712
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3968 - 3968
+gpbeam = 10.537409815295565
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3969 - 3969
+gpbeam = 10.53714271537922
+gtargmass_amu = 1.007825032
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3970 - 3970
+gpbeam = 10.537204183921848
+gtargmass_amu = 26.981539
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3971 - 3971
+gpbeam = 10.537308788060894
+gtargmass_amu = 26.981539
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3972 - 3972
+gpbeam = 10.537635401606611
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3973 - 3973
+gpbeam = 10.53776883270588
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3974 - 3974
+gpbeam = 10.537834389453788
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3975 - 3975
+gpbeam = 10.537675249194972
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3976 - 3976
+gpbeam = 10.537774041796686
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3977 - 3977
+gpbeam = 10.538010885094776
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3978 - 3978
+gpbeam = 10.537382599838566
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3979 - 3979
+gpbeam = 10.53771317997563
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3980 - 3980
+gpbeam = 10.537710011801039
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3981 - 3981
+gpbeam = 10.537728548237816
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3982 - 3982
+gpbeam = 10.537635704194711
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3983 - 3983
+gpbeam = 10.53749395741391
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3984 - 3984
+gpbeam = 10.537847566155943
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3985 - 3985
+gpbeam = 10.53777273789432
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3986 - 3986
+gpbeam = 10.537694840338238
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3987 - 3987
+gpbeam = 10.537436489636924
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3988 - 3988
+gpbeam = 10.5374902998899
+gtargmass_amu = 2.014101778
+htheta_lab = -16.93
+hpcentral = 5.253
+stheta_lab = 33.18
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3989 - 3989
+gpbeam = 10.53888059031645
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3990 - 3990
+gpbeam = 10.538132642076974
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3991 - 3991
+gpbeam = 10.538109386789483
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3992 - 3992
+gpbeam = 10.53814148647002
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3993 - 3993
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3994 - 3994
+gpbeam = 10.536649095202707
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3995 - 3995
+gpbeam = 10.536311167282513
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3996 - 3996
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3997 - 3997
+gpbeam = 10.53539101037012
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3998 - 3998
+gpbeam = 10.535416440234808
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+3999 - 3999
+gpbeam = 10.536293444776083
+gtargmass_amu = 26.981539
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4000 - 4000
+gpbeam = 10.536037811574234
+gtargmass_amu = 26.981539
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4001 - 4001
+gpbeam = 10.536725791369891
+gtargmass_amu = 26.981539
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4002 - 4002
+gpbeam = 10.537174682397316
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4003 - 4003
+gpbeam = 10.536153174821205
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4004 - 4004
+gpbeam = 10.53590134980048
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4005 - 4005
+gpbeam = 10.535941880864073
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4006 - 4006
+gpbeam = 10.537211740213042
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4007 - 4007
+gpbeam = 10.536013024345568
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4008 - 4008
+gpbeam = 10.53611526224379
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4009 - 4009
+gpbeam = 10.53594579952651
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4010 - 4010
+gpbeam = 10.5359903977374
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4011 - 4011
+gpbeam = 10.536050080470277
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4012 - 4012
+gpbeam = 10.536133094742759
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4013 - 4013
+gpbeam = 10.5359093288687
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4014 - 4014
+gpbeam = 10.535578214772936
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4015 - 4015
+gpbeam = 10.536694462310148
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4016 - 4016
+gpbeam = 10.538448881603806
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4017 - 4017
+gpbeam = 10.536351988923055
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4018 - 4018
+gpbeam = 10.536533867584842
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4019 - 4019
+gpbeam = 10.53577395975256
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4020 - 4020
+gpbeam = 10.537028068849983
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4021 - 4021
+gpbeam = 10.532746042407165
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4022 - 4022
+gpbeam = 10.537967629467023
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4023 - 4023
+gpbeam = 10.536036870086326
+gtargmass_amu = 1.007825032
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4024 - 4024
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4025 - 4025
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4026 - 4026
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4027 - 4027
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4028 - 4028
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4029 - 4029
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 31.64
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4030 - 4030
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 31.64
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4032 - 4032
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 31.64
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4033 - 4033
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4034 - 4034
+gpbeam = 10.537831837989923
+gtargmass_amu = 26.981539
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4035 - 4035
+gpbeam = 10.53756636047629
+gtargmass_amu = 26.981539
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4036 - 4036
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4037 - 4037
+gpbeam = 10.537653585678111
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4038 - 4038
+gpbeam = 10.537650545945787
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4039 - 4039
+gpbeam = 10.53753107873129
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4040 - 4040
+gpbeam = 10.537315410212562
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4041 - 4041
+gpbeam = 10.537114599627998
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4042 - 4042
+gpbeam = 10.537157046352759
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4043 - 4043
+gpbeam = 10.537363877169364
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4044 - 4044
+gpbeam = 10.53735838125984
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4045 - 4045
+gpbeam = 10.537095377087558
+gtargmass_amu = 2.014101778
+htheta_lab = -16.44
+hpcentral = 4.637
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4046 - 4046
+gpbeam = 10.537429786001145
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4047 - 4047
+gpbeam = 10.537558018418235
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4048 - 4048
+gpbeam = 10.537954049762371
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 32.83
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4049 - 4049
+gpbeam = 10.53830473103256
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4050 - 4050
+gpbeam = 10.538362718304763
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4051 - 4051
+gpbeam = 10.538262665854038
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4052 - 4052
+gpbeam = 10.538283837136802
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4053 - 4053
+gpbeam = 10.538255433299627
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4054 - 4054
+gpbeam = 10.538205992532157
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4055 - 4055
+gpbeam = 10.538228469076264
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4056 - 4056
+gpbeam = 10.538148423789963
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4057 - 4057
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4058 - 4058
+gpbeam = 10.538315501859895
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4059 - 4059
+gpbeam = 10.53799083578449
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4060 - 4060
+gpbeam = 10.538176794818991
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4061 - 4061
+gpbeam = 10.538207107414042
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4062 - 4062
+gpbeam = 10.537512441588317
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4063 - 4063
+gpbeam = 10.53873760274936
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4064 - 4064
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4065 - 4065
+gpbeam = 10.538167726078429
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4066 - 4066
+gpbeam = 10.538281116592238
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4067 - 4067
+gpbeam = 10.538146371671786
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4068 - 4068
+gpbeam = 10.538138106632578
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4069 - 4069
+gpbeam = 10.538145488322957
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4070 - 4070
+gpbeam = 10.536178595589293
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4071 - 4071
+gpbeam = 10.53825370401901
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4072 - 4072
+gpbeam = 10.53818369314184
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4073 - 4073
+gpbeam = 10.538006018423001
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4074 - 4074
+gpbeam = 10.53820217932146
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4075 - 4075
+gpbeam = 10.53787907475014
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4076 - 4076
+gpbeam = 10.538194464452388
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4077 - 4077
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4078 - 4078
+gpbeam = 10.538309470495058
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4079 - 4079
+gpbeam = 10.538246783929635
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4080 - 4080
+gpbeam = 10.538210551813673
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4081 - 4081
+gpbeam = 10.53885527407325
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4082 - 4082
+gpbeam = 10.538854089594201
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4083 - 4083
+gpbeam = 10.538462255946014
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4084 - 4084
+gpbeam = 10.538273733523472
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4085 - 4085
+gpbeam = 10.53821662233609
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4086 - 4086
+gpbeam = 10.538291236283184
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4087 - 4087
+gpbeam = 10.538247606964436
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4088 - 4088
+gpbeam = 10.538235726583459
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4089 - 4089
+gpbeam = 10.538291206963901
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4090 - 4090
+gpbeam = 10.538869418043552
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4091 - 4091
+gpbeam = 10.538245487865524
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4092 - 4092
+gpbeam = 10.538112736064473
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4093 - 4093
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4094 - 4094
+gpbeam = 10.538337376933049
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4095 - 4095
+gpbeam = 10.538345604605812
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4096 - 4096
+gpbeam = 10.538147624775949
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4097 - 4097
+gpbeam = 10.538209315859024
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4098 - 4098
+gpbeam = 10.538248037030025
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4099 - 4099
+gpbeam = 10.538225519767044
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4100 - 4100
+gpbeam = 10.53827769206658
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4101 - 4101
+gpbeam = 10.538222561734091
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4102 - 4102
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4103 - 4103
+gpbeam = 10.537913985794436
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4104 - 4104
+gpbeam = 10.537812089721228
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4105 - 4105
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4106 - 4106
+gpbeam = 10.538546810613818
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4107 - 4107
+gpbeam = 10.538398607233432
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4108 - 4108
+gpbeam = 10.538268292323238
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4109 - 4109
+gpbeam = 10.538363078684268
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4110 - 4110
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4111 - 4111
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4112 - 4112
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4113 - 4113
+gpbeam = 10.538232811363795
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4114 - 4114
+gpbeam = 10.538173331720555
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4115 - 4115
+gpbeam = 10.538190748201862
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4116 - 4116
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4117 - 4117
+gpbeam = 10.538151515416697
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4118 - 4118
+gpbeam = 10.538223926517851
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4119 - 4119
+gpbeam = 10.53818380090888
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4120 - 4120
+gpbeam = 10.538334447813936
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4121 - 4121
+gpbeam = 10.538202185613295
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4122 - 4122
+gpbeam = 10.53841135984325
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4123 - 4123
+gpbeam = 10.538310306423956
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4124 - 4124
+gpbeam = 10.538243420890616
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4125 - 4125
+gpbeam = 10.538404892678356
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4126 - 4126
+gpbeam = 10.53837967594101
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4127 - 4127
+gpbeam = 10.53803117653061
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4128 - 4128
+gpbeam = 10.53834098342869
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4129 - 4129
+gpbeam = 10.538065628405704
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4130 - 4130
+gpbeam = 10.536619552835326
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4131 - 4131
+gpbeam = 10.538220776501262
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4132 - 4132
+gpbeam = 10.535934286929907
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4133 - 4133
+gpbeam = 10.535939595178938
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4134 - 4134
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4135 - 4135
+gpbeam = 10.535326667696323
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4136 - 4136
+gpbeam = 10.535686743286744
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4137 - 4137
+gpbeam = 10.535388605384009
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4138 - 4138
+gpbeam = 10.53591191812163
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4139 - 4139
+gpbeam = 10.53604074486886
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4140 - 4140
+gpbeam = 10.535922405097134
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4141 - 4141
+gpbeam = 10.535864646494757
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4142 - 4142
+gpbeam = 10.535810172384108
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4143 - 4143
+gpbeam = 10.535982076845805
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4144 - 4144
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4145 - 4145
+gpbeam = 10.536000016748874
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4146 - 4146
+gpbeam = 10.536288076849507
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4147 - 4147
+gpbeam = 10.535460088147929
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4148 - 4148
+gpbeam = 10.536748329613623
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4149 - 4149
+gpbeam = 10.536143760006382
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4150 - 4150
+gpbeam = 10.536097299793118
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4151 - 4151
+gpbeam = 10.538576151191988
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4152 - 4152
+gpbeam = 10.53589256378702
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4153 - 4153
+gpbeam = 10.5360520827996
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4154 - 4154
+gpbeam = 10.53604264890407
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4155 - 4155
+gpbeam = 10.536117254255105
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4156 - 4156
+gpbeam = 10.536110910856221
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4157 - 4157
+gpbeam = 10.536079795857372
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4158 - 4158
+gpbeam = 10.536006349333064
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4159 - 4159
+gpbeam = 10.535955791974816
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4160 - 4160
+gpbeam = 10.535966005946328
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4161 - 4161
+gpbeam = 10.536091106844648
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4162 - 4162
+gpbeam = 10.53686189080736
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4163 - 4163
+gpbeam = 10.538459070899146
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4164 - 4164
+gpbeam = 10.536561843015786
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4165 - 4165
+gpbeam = 10.536057713025128
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4166 - 4166
+gpbeam = 10.536108490352857
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4167 - 4167
+gpbeam = 10.536078911070314
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4168 - 4168
+gpbeam = 10.536054941167043
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4169 - 4169
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4170 - 4170
+gpbeam = 10.536109694447378
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4171 - 4171
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4172 - 4172
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4173 - 4173
+gpbeam = 10.53581413879339
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4174 - 4174
+gpbeam = 10.536030766068256
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4175 - 4175
+gpbeam = 10.535995916608936
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4176 - 4176
+gpbeam = 10.536027432265373
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4177 - 4177
+gpbeam = 10.536017042216493
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4178 - 4178
+gpbeam = 10.535992508177976
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4179 - 4179
+gpbeam = 10.53581751731646
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4180 - 4180
+gpbeam = 10.53603123198001
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4181 - 4181
+gpbeam = 10.53847167426253
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4182 - 4182
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4183 - 4183
+gpbeam = 10.537866146434144
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4184 - 4184
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4185 - 4185
+gpbeam = 10.538210249341052
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4186 - 4186
+gpbeam = 10.538332639673518
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4187 - 4187
+gpbeam = 10.538825324083765
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4188 - 4188
+gpbeam = 10.538816028942767
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4189 - 4189
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4190 - 4190
+gpbeam = 10.538275111837596
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4191 - 4191
+gpbeam = 10.53831675688917
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4192 - 4192
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4193 - 4193
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4194 - 4194
+gpbeam = 10.537742743448854
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4195 - 4195
+gpbeam = 10.538332267964602
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4196 - 4196
+gpbeam = 10.538297443911045
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4197 - 4197
+gpbeam = 10.538162014232144
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4198 - 4198
+gpbeam = 10.538852208300657
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4199 - 4199
+gpbeam = 10.538315093348846
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4200 - 4200
+gpbeam = 10.53825166350681
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4201 - 4201
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4202 - 4202
+gpbeam = 10.53820575997241
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 33.02
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4203 - 4203
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4204 - 4204
+gpbeam = 10.53817567979343
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4205 - 4205
+gpbeam = 10.53820188516341
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4206 - 4206
+gpbeam = 10.538246433286552
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4207 - 4207
+gpbeam = 10.53817978059199
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4208 - 4208
+gpbeam = 10.538140453330799
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4209 - 4209
+gpbeam = 10.538209530548315
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4210 - 4210
+gpbeam = 10.53818792167993
+gtargmass_amu = 1.007825032
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4211 - 4211
+gpbeam = 10.53821370940052
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4212 - 4212
+gpbeam = 10.538165217271034
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4213 - 4213
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4214 - 4214
+gpbeam = 10.538281898485387
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4215 - 4215
+gpbeam = 10.538380100571151
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4216 - 4216
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4217 - 4217
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4218 - 4218
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4219 - 4219
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4220 - 4220
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -16.48
+hpcentral = 5.878
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4221 - 4221
+gpbeam = 10.5388154660745
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.038
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4222 - 4222
+gpbeam = 10.539066878249757
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.038
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4223 - 4223
+gpbeam = 10.537714572688635
+gtargmass_amu = 0.0
+htheta_lab = -16.48
+hpcentral = 5.038
+stheta_lab = 36.45
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4224 - 4224
+gpbeam = 10.53886941550712
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4225 - 4225
+gpbeam = 10.53835560281554
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4226 - 4226
+gpbeam = 10.538343383822482
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4227 - 4227
+gpbeam = 10.538360828898716
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4228 - 4228
+gpbeam = 10.538749404274741
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4245 - 4245
+gpbeam = 10.538298197371171
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4246 - 4246
+gpbeam = 10.538149563727861
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4247 - 4247
+gpbeam = 10.538332494007031
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4248 - 4248
+gpbeam = 10.53807116520313
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4249 - 4249
+gpbeam = 10.538290942634525
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4250 - 4250
+gpbeam = 10.538176911911254
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4251 - 4251
+gpbeam = 10.538251630346501
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4252 - 4252
+gpbeam = 10.538466225102203
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4253 - 4253
+gpbeam = 10.538427923661889
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4254 - 4254
+gpbeam = 10.538353732947076
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4255 - 4255
+gpbeam = 10.537986361470539
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4256 - 4256
+gpbeam = 10.538070895317363
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4257 - 4257
+gpbeam = 10.537988926233602
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4258 - 4258
+gpbeam = 10.538145130240311
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4259 - 4259
+gpbeam = 10.53842900298132
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4260 - 4260
+gpbeam = 10.535732700187875
+gtargmass_amu = 26.981539
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4261 - 4261
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4262 - 4262
+gpbeam = 10.538067082141424
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4263 - 4263
+gpbeam = 10.538100383964775
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4264 - 4264
+gpbeam = 10.538066069495352
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4265 - 4265
+gpbeam = 10.537977282392966
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4266 - 4266
+gpbeam = 10.537975913397055
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4267 - 4267
+gpbeam = 10.538130330503506
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4268 - 4268
+gpbeam = 10.538173880203809
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4269 - 4269
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4270 - 4270
+gpbeam = 10.53814068977357
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4271 - 4271
+gpbeam = 10.538141293650224
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4272 - 4272
+gpbeam = 10.538222440678203
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4273 - 4273
+gpbeam = 10.538198474234736
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4274 - 4274
+gpbeam = 10.538097888200001
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4275 - 4275
+gpbeam = 10.538570295331661
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4276 - 4276
+gpbeam = 10.538096359037521
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4277 - 4277
+gpbeam = 10.538817513608256
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4278 - 4278
+gpbeam = 10.538174761965434
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4279 - 4279
+gpbeam = 10.538151901932524
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4280 - 4280
+gpbeam = 10.537989876318973
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4281 - 4281
+gpbeam = 10.538210837234832
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4282 - 4282
+gpbeam = 10.538015411077057
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4283 - 4283
+gpbeam = 10.538009257195592
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4284 - 4284
+gpbeam = 10.537945034601279
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4285 - 4285
+gpbeam = 10.538022439699342
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4286 - 4286
+gpbeam = 10.537940055938755
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4287 - 4287
+gpbeam = 10.538011744512698
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4288 - 4288
+gpbeam = 10.537934473828656
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4289 - 4289
+gpbeam = 10.537991212836744
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4290 - 4290
+gpbeam = 10.53800883738885
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4291 - 4291
+gpbeam = 10.538031252831605
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4292 - 4292
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4293 - 4293
+gpbeam = 10.538018233806927
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4294 - 4294
+gpbeam = 10.53812220328995
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4295 - 4295
+gpbeam = 10.538025127979793
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4296 - 4296
+gpbeam = 10.537840184329994
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4297 - 4297
+gpbeam = 10.538432543560775
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4298 - 4298
+gpbeam = 10.538017632010988
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4299 - 4299
+gpbeam = 10.538072389577051
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4300 - 4300
+gpbeam = 10.538369140850566
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4301 - 4301
+gpbeam = 10.53849666414233
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4302 - 4302
+gpbeam = 10.538449593264117
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4303 - 4303
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4304 - 4304
+gpbeam = 10.53810965827172
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4305 - 4305
+gpbeam = 10.53803938636346
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4306 - 4306
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4307 - 4307
+gpbeam = 10.538172557761547
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4308 - 4308
+gpbeam = 10.538195743015235
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4309 - 4309
+gpbeam = 10.535671555838388
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4310 - 4310
+gpbeam = 10.535678303118535
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4311 - 4311
+gpbeam = 10.535574247035573
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4312 - 4312
+gpbeam = 10.535637819924112
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4313 - 4313
+gpbeam = 10.53799739053487
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4314 - 4314
+gpbeam = 10.538027733152004
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4315 - 4315
+gpbeam = 10.538131239279242
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4316 - 4316
+gpbeam = 10.538165810056718
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4317 - 4317
+gpbeam = 10.538052488960966
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4318 - 4318
+gpbeam = 10.538078447048989
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4319 - 4319
+gpbeam = 10.538025981673368
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4320 - 4320
+gpbeam = 10.538075098862318
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4321 - 4321
+gpbeam = 10.536884399587855
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4322 - 4322
+gpbeam = 10.53804162251592
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4323 - 4323
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4324 - 4324
+gpbeam = 10.538150334780253
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4325 - 4325
+gpbeam = 10.538317801959954
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4326 - 4326
+gpbeam = 10.538220272398563
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4327 - 4327
+gpbeam = 10.538258675553665
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4328 - 4328
+gpbeam = 10.538114382637948
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4329 - 4329
+gpbeam = 10.538308214095478
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4330 - 4330
+gpbeam = 10.53829302333133
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4331 - 4331
+gpbeam = 10.538146779049974
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4332 - 4332
+gpbeam = 10.538034110205299
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4333 - 4333
+gpbeam = 10.53763022362046
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4334 - 4334
+gpbeam = 10.538820768370474
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4335 - 4335
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4336 - 4336
+gpbeam = 10.539709475060487
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4337 - 4337
+gpbeam = 10.538279290574458
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4338 - 4338
+gpbeam = 10.538067985853456
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4339 - 4339
+gpbeam = 10.538131742554942
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4340 - 4340
+gpbeam = 10.538210115966415
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4341 - 4341
+gpbeam = 10.53801362126956
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4342 - 4342
+gpbeam = 10.538125243124853
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4343 - 4343
+gpbeam = 10.538681340230555
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4344 - 4344
+gpbeam = 10.538124335140099
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4345 - 4345
+gpbeam = 10.538027743571792
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4346 - 4346
+gpbeam = 10.536835796580517
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4347 - 4347
+gpbeam = 10.537966861375365
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4348 - 4348
+gpbeam = 10.538166282992657
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4349 - 4349
+gpbeam = 10.538292899590553
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4350 - 4350
+gpbeam = 10.538374860755155
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4351 - 4351
+gpbeam = 10.538238007675552
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4352 - 4352
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4353 - 4353
+gpbeam = 10.538208969746155
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4354 - 4354
+gpbeam = 10.538341086545035
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4355 - 4355
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4356 - 4356
+gpbeam = 10.538113214380004
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4357 - 4357
+gpbeam = 10.538254490405803
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4358 - 4358
+gpbeam = 10.538086010499288
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4359 - 4359
+gpbeam = 10.538040347108986
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4360 - 4360
+gpbeam = 10.538108748488643
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4361 - 4361
+gpbeam = 10.53808811051332
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+ 
+4362 - 4362
+gpbeam = 10.538120765178745
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4363 - 4363
+gpbeam = 10.538012083247278
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4364 - 4364
+gpbeam = 10.538146630021142
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4365 - 4365
+gpbeam = 10.538204236358006
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4366 - 4366
+gpbeam = 10.53806045614153
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4367 - 4367
+gpbeam = 10.538055637388581
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4368 - 4368
+gpbeam = 10.538013654667393
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4369 - 4369
+gpbeam = 10.538030564247551
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4370 - 4370
+gpbeam = 10.538045796095561
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4371 - 4371
+gpbeam = 10.538210398382056
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4372 - 4372
+gpbeam = 10.53727258664065
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4373 - 4373
+gpbeam = 10.541576741901332
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4374 - 4374
+gpbeam = 10.538336364538296
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4375 - 4375
+gpbeam = 10.538199434227906
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4376 - 4376
+gpbeam = 10.53819566921106
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4377 - 4377
+gpbeam = 10.538026027112043
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4378 - 4378
+gpbeam = 10.538391210907879
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4379 - 4379
+gpbeam = 10.538051993636234
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4380 - 4380
+gpbeam = 10.538086492478836
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4381 - 4381
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4382 - 4382
+gpbeam = 10.537947630244467
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4383 - 4383
+gpbeam = 10.538069323711643
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4384 - 4384
+gpbeam = 10.538033445327665
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4385 - 4385
+gpbeam = 10.53786602325633
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4386 - 4386
+gpbeam = 10.538263089013752
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4387 - 4387
+gpbeam = 10.537845798340989
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4388 - 4388
+gpbeam = 10.538030388013691
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4389 - 4389
+gpbeam = 10.538168297961917
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4390 - 4390
+gpbeam = 10.53805340785506
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4391 - 4391
+gpbeam = 10.53798032113778
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4392 - 4392
+gpbeam = 10.53804328335203
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4393 - 4393
+gpbeam = 10.537997286750908
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4394 - 4394
+gpbeam = 10.537718555222776
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4395 - 4395
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4396 - 4396
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4397 - 4397
+gpbeam = 10.537548820829134
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4398 - 4398
+gpbeam = 10.538268939049726
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4399 - 4399
+gpbeam = 10.53792162630079
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4400 - 4400
+gpbeam = 10.538160437256895
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4401 - 4401
+gpbeam = 10.537949793186709
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4402 - 4402
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4403 - 4403
+gpbeam = 10.538065329647843
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4404 - 4404
+gpbeam = 10.538300889724876
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4405 - 4405
+gpbeam = 10.538508047500564
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4406 - 4406
+gpbeam = 10.538458595427876
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4407 - 4407
+gpbeam = 10.538013851410751
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4408 - 4408
+gpbeam = 10.5380100289122
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4409 - 4409
+gpbeam = 10.537935500629414
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4410 - 4410
+gpbeam = 10.538508047500564
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4411 - 4411
+gpbeam = 10.538091966534685
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4412 - 4412
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 38.0
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4413 - 4413
+gpbeam = 10.538062961861964
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4414 - 4414
+gpbeam = 10.538125764080393
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4415 - 4415
+gpbeam = 10.538047986230286
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4417 - 4417
+gpbeam = 10.53794274529339
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4418 - 4418
+gpbeam = 10.538001889534355
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4419 - 4419
+gpbeam = 10.53799426735377
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4420 - 4420
+gpbeam = 10.538118507335266
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4421 - 4421
+gpbeam = 10.537957361292415
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4422 - 4422
+gpbeam = 10.538127988969704
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4423 - 4423
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4424 - 4424
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4425 - 4425
+gpbeam = 10.538148619207824
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4426 - 4426
+gpbeam = 10.538236917713496
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4427 - 4427
+gpbeam = 10.538292216883821
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4428 - 4428
+gpbeam = 10.538309077956942
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.38
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4429 - 4429
+gpbeam = 10.533027962717757
+gtargmass_amu = 0.0
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 37.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4430 - 4430
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 37.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4431 - 4431
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 37.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4432 - 4432
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 37.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4433 - 4433
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 37.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4434 - 4434
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 37.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4435 - 4435
+gpbeam = 10.538508047500564
+gtargmass_amu = 0.0
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4436 - 4436
+gpbeam = 10.538508047500564
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4437 - 4437
+gpbeam = 10.537116905732882
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4438 - 4438
+gpbeam = 10.536956563337718
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4439 - 4439
+gpbeam = 10.53774461031595
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4440 - 4440
+gpbeam = 10.537099438507541
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4441 - 4441
+gpbeam = 10.537416166116447
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4442 - 4442
+gpbeam = 10.53734061317215
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4443 - 4443
+gpbeam = 10.537328693276077
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4444 - 4444
+gpbeam = 10.537284875111443
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4445 - 4445
+gpbeam = 10.537982957941276
+gtargmass_amu = 1.007825032
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4446 - 4446
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4447 - 4447
+gpbeam = 10.537255817154557
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4448 - 4448
+gpbeam = 10.537250909020527
+gtargmass_amu = 26.981539
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4449 - 4449
+gpbeam = 10.537395467001573
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4450 - 4450
+gpbeam = 10.53718727778193
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4451 - 4451
+gpbeam = 10.537219241677592
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4452 - 4452
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4453 - 4453
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4454 - 4454
+gpbeam = 10.537381452188455
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4455 - 4455
+gpbeam = 10.537381769655585
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4456 - 4456
+gpbeam = 10.53734311715742
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4457 - 4457
+gpbeam = 10.537290867856989
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4458 - 4458
+gpbeam = 10.537232896773679
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4459 - 4459
+gpbeam = 10.53785799399288
+gtargmass_amu = 2.014101778
+htheta_lab = -19.35
+hpcentral = 5.038
+stheta_lab = 30.39
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4460 - 4460
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.35
+hpcentral = 4.064
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4461 - 4461
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.35
+hpcentral = 4.064
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4462 - 4462
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.35
+hpcentral = 4.064
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4463 - 4463
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.35
+hpcentral = 4.064
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4464 - 4464
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.35
+hpcentral = 4.064
+stheta_lab = 37.9
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4465 - 4465
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -30.0
+hpcentral = 4.064
+stheta_lab = 31.1
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4466 - 4466
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -30.0
+hpcentral = 4.064
+stheta_lab = 31.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4467 - 4467
+gpbeam = 10.538524287252265
+gtargmass_amu = 1.007825032
+htheta_lab = -30.0
+hpcentral = 4.064
+stheta_lab = 31.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4468 - 4468
+gpbeam = 10.538346073178879
+gtargmass_amu = 1.007825032
+htheta_lab = -30.0
+hpcentral = 4.064
+stheta_lab = 31.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4469 - 4469
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -30.0
+hpcentral = 4.064
+stheta_lab = 31.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4470 - 4470
+gpbeam = 10.538254267080443
+gtargmass_amu = 1.007825032
+htheta_lab = -30.0
+hpcentral = 4.064
+stheta_lab = 32.26
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4471 - 4471
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -30.0
+hpcentral = 4.064
+stheta_lab = 33.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4472 - 4472
+gpbeam = 10.537330774838486
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4473 - 4473
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4474 - 4474
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4475 - 4475
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4476 - 4476
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4477 - 4477
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4478 - 4478
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4479 - 4479
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4480 - 4480
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4481 - 4481
+gpbeam = 10.537276542425664
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4482 - 4482
+gpbeam = 10.537212282014188
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4483 - 4483
+gpbeam = 10.53721600173757
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4484 - 4484
+gpbeam = 10.537373645687701
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4485 - 4485
+gpbeam = 10.537312810211674
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4486 - 4486
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4487 - 4487
+gpbeam = 10.537315904996474
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4488 - 4488
+gpbeam = 10.538027133715085
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4489 - 4489
+gpbeam = 10.537356390781705
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4490 - 4490
+gpbeam = 10.537222934311611
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4491 - 4491
+gpbeam = 10.537866049017548
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4492 - 4492
+gpbeam = 10.537689422594138
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4493 - 4493
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4494 - 4494
+gpbeam = 10.537279609980597
+gtargmass_amu = 26.981539
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4495 - 4495
+gpbeam = 10.537260317988666
+gtargmass_amu = 26.981539
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4496 - 4496
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4497 - 4497
+gpbeam = 10.537307687734675
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4498 - 4498
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4499 - 4499
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4500 - 4500
+gpbeam = 10.537240841652519
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4501 - 4501
+gpbeam = 10.536160563536184
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4502 - 4502
+gpbeam = 10.537365271581672
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4503 - 4503
+gpbeam = 10.537291807677565
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4504 - 4504
+gpbeam = 10.537310369965107
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4505 - 4505
+gpbeam = 10.537255663101183
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4506 - 4506
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4507 - 4507
+gpbeam = 10.535860122363621
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4508 - 4508
+gpbeam = 10.537138633712113
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4509 - 4509
+gpbeam = 10.537184259373923
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.81
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4510 - 4510
+gpbeam = 10.537220635135078
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4511 - 4511
+gpbeam = 10.537898857813568
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4512 - 4512
+gpbeam = 10.537293171513323
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4513 - 4513
+gpbeam = 10.537379952532882
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4514 - 4514
+gpbeam = 10.537338757279906
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4515 - 4515
+gpbeam = 10.537232998451707
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4516 - 4516
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4517 - 4517
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4518 - 4518
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4519 - 4519
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.76
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4520 - 4520
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.78
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4521 - 4521
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4522 - 4522
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4523 - 4523
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4524 - 4524
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4525 - 4525
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4526 - 4526
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4527 - 4527
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4528 - 4528
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4529 - 4529
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4530 - 4530
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4531 - 4531
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4532 - 4532
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4533 - 4533
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4534 - 4534
+gpbeam = 10.53913859604503
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4535 - 4535
+gpbeam = 10.537225029310294
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4536 - 4536
+gpbeam = 10.53721142152397
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4537 - 4537
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4538 - 4538
+gpbeam = 10.537164542215399
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4539 - 4539
+gpbeam = 10.537147076610655
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 39.64
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4540 - 4540
+gpbeam = 10.537266335114012
+gtargmass_amu = 26.981539
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4541 - 4541
+gpbeam = 10.537218001030752
+gtargmass_amu = 26.981539
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4542 - 4542
+gpbeam = 10.53728289298647
+gtargmass_amu = 26.981539
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4543 - 4543
+gpbeam = 10.53792894379314
+gtargmass_amu = 26.981539
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4544 - 4544
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4545 - 4545
+gpbeam = 10.537185396542174
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.375
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4546 - 4546
+gpbeam = 10.537208737354385
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4547 - 4547
+gpbeam = 10.537332165514886
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4548 - 4548
+gpbeam = 10.537105948762049
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4549 - 4549
+gpbeam = 10.538004962804232
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4550 - 4550
+gpbeam = 10.538548119041417
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 30.37
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4551 - 4551
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4552 - 4552
+gpbeam = 10.537341595760745
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4553 - 4553
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4554 - 4554
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4555 - 4555
+gpbeam = 10.53716569903161
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4556 - 4556
+gpbeam = 10.537091057300415
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4557 - 4557
+gpbeam = 10.537850485908486
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4558 - 4558
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4559 - 4559
+gpbeam = 10.537702380708094
+gtargmass_amu = 26.981539
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4560 - 4560
+gpbeam = 10.537081323855904
+gtargmass_amu = 26.981539
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4561 - 4561
+gpbeam = 10.537128086291183
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4562 - 4562
+gpbeam = 10.53725872303306
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4563 - 4563
+gpbeam = 10.537296333045544
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4564 - 4564
+gpbeam = 10.537269481530224
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4565 - 4565
+gpbeam = 10.537272573163548
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4566 - 4566
+gpbeam = 10.537195703608157
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4567 - 4567
+gpbeam = 10.537214288202598
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4568 - 4568
+gpbeam = 10.537232010837975
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4569 - 4569
+gpbeam = 10.537223254092725
+gtargmass_amu = 2.014101778
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4570 - 4570
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -19.36
+hpcentral = 5.038
+stheta_lab = 33.82
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4571 - 4571
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -20.72
+hpcentral = 2.416
+stheta_lab = 33.97
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4572 - 4572
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -20.72
+hpcentral = 2.416
+stheta_lab = 31.98
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4573 - 4573
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -20.72
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4574 - 4574
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4575 - 4575
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4576 - 4576
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4577 - 4577
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4578 - 4578
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4579 - 4579
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4580 - 4580
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4581 - 4581
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4582 - 4582
+gpbeam = 10.538064765143197
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4583 - 4583
+gpbeam = 10.538029362352543
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4584 - 4584
+gpbeam = 10.53777068298601
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4585 - 4585
+gpbeam = 10.537500469536065
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4586 - 4586
+gpbeam = 10.537494055825192
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4587 - 4587
+gpbeam = 10.538050061428645
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4588 - 4588
+gpbeam = 10.537823482658958
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4589 - 4589
+gpbeam = 10.537963923426393
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4590 - 4590
+gpbeam = 10.537992162365434
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4591 - 4591
+gpbeam = 10.537917149923913
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4592 - 4592
+gpbeam = 10.537736975924991
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4593 - 4593
+gpbeam = 10.538073944785964
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4594 - 4594
+gpbeam = 10.537864623322264
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4595 - 4595
+gpbeam = 10.537903938536266
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4596 - 4596
+gpbeam = 10.538068447211772
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4597 - 4597
+gpbeam = 10.537696665708905
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4598 - 4598
+gpbeam = 10.536836794206742
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4599 - 4599
+gpbeam = 10.537508363548321
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4600 - 4600
+gpbeam = 10.537572241381472
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4601 - 4601
+gpbeam = 10.53776558987357
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4602 - 4602
+gpbeam = 10.538793400162636
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4603 - 4603
+gpbeam = 10.5390143021962
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4604 - 4604
+gpbeam = 10.537642802661988
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4605 - 4605
+gpbeam = 10.537651594234495
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4606 - 4606
+gpbeam = 10.537309386855545
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4607 - 4607
+gpbeam = 10.537827879057216
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4608 - 4608
+gpbeam = 10.537370211073359
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4609 - 4609
+gpbeam = 10.537974725846171
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4610 - 4610
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4611 - 4611
+gpbeam = 10.537667509581324
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4612 - 4612
+gpbeam = 10.537704814589604
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4613 - 4613
+gpbeam = 10.53772018183747
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4614 - 4614
+gpbeam = 10.5381777362891
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4615 - 4615
+gpbeam = 10.537423165955904
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4616 - 4616
+gpbeam = 10.537309531517392
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4617 - 4617
+gpbeam = 10.5371449599274
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4618 - 4618
+gpbeam = 10.537632439736374
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4619 - 4619
+gpbeam = 10.537752551804521
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4620 - 4620
+gpbeam = 10.53798514559532
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4621 - 4621
+gpbeam = 10.538034710914866
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4622 - 4622
+gpbeam = 10.538493233352352
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4623 - 4623
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4624 - 4624
+gpbeam = 10.538038680055054
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4625 - 4625
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4626 - 4626
+gpbeam = 10.538025667605483
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4627 - 4627
+gpbeam = 10.537947493130439
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4628 - 4628
+gpbeam = 10.538146939316336
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4629 - 4629
+gpbeam = 10.537885155124469
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4630 - 4630
+gpbeam = 10.537960460478093
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4631 - 4631
+gpbeam = 10.538003620765696
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4632 - 4632
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4633 - 4633
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4634 - 4634
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4635 - 4635
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4636 - 4636
+gpbeam = 10.537707375323318
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4637 - 4637
+gpbeam = 10.537692879528116
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4638 - 4638
+gpbeam = 10.537604257495355
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4639 - 4639
+gpbeam = 10.537571635649085
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4640 - 4640
+gpbeam = 10.53769665724793
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4641 - 4641
+gpbeam = 10.537633452011715
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4642 - 4642
+gpbeam = 10.53763139357747
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4643 - 4643
+gpbeam = 10.537690975890579
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4644 - 4644
+gpbeam = 10.53768606210261
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4645 - 4645
+gpbeam = 10.537943228512868
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4646 - 4646
+gpbeam = 10.537943228512868
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4647 - 4647
+gpbeam = 10.537943228512868
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4648 - 4648
+gpbeam = 10.537943228512868
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4649 - 4649
+gpbeam = 10.537943228512868
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4650 - 4650
+gpbeam = 10.537943228512868
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4651 - 4651
+gpbeam = 10.537943228512868
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4652 - 4652
+gpbeam = 10.537943228512868
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4653 - 4653
+gpbeam = 10.537943228512868
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4654 - 4654
+gpbeam = 10.537943228512868
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4655 - 4655
+gpbeam = 10.537702380708094
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4656 - 4656
+gpbeam = 10.537702380708094
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4657 - 4657
+gpbeam = 10.538143223541526
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4658 - 4658
+gpbeam = 10.538091577090066
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4659 - 4659
+gpbeam = 10.538045551172823
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4660 - 4660
+gpbeam = 10.53797238902024
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4661 - 4661
+gpbeam = 10.5380589687733
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4662 - 4662
+gpbeam = 10.537971108828685
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4663 - 4663
+gpbeam = 10.537925076161219
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4664 - 4664
+gpbeam = 10.538088244074995
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4665 - 4665
+gpbeam = 10.537886420541733
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4666 - 4666
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4667 - 4667
+gpbeam = 10.538046305858245
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4668 - 4668
+gpbeam = 10.537886275504626
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4669 - 4669
+gpbeam = 10.537774593262128
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4670 - 4670
+gpbeam = 10.53790605825913
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4671 - 4671
+gpbeam = 10.537889776208258
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4672 - 4672
+gpbeam = 10.53775074387478
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4673 - 4673
+gpbeam = 10.537614214362426
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4674 - 4674
+gpbeam = 10.53769224288194
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4675 - 4675
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4676 - 4676
+gpbeam = 10.537701924356792
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4677 - 4677
+gpbeam = 10.537774598040016
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4678 - 4678
+gpbeam = 10.537641694879287
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4679 - 4679
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4680 - 4680
+gpbeam = 10.537764727732363
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4681 - 4681
+gpbeam = 10.537690287407356
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4682 - 4682
+gpbeam = 10.537697270064873
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4683 - 4683
+gpbeam = 10.537563511905127
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4684 - 4684
+gpbeam = 10.537536475953418
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4685 - 4685
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4686 - 4686
+gpbeam = 10.537644419587252
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4687 - 4687
+gpbeam = 10.537744459269087
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4688 - 4688
+gpbeam = 10.537832144665895
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4689 - 4689
+gpbeam = 10.537691488935797
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4690 - 4690
+gpbeam = 10.537751456577295
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4691 - 4691
+gpbeam = 10.537732545810957
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4692 - 4692
+gpbeam = 10.537654800588582
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4693 - 4693
+gpbeam = 10.537473089981658
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4694 - 4694
+gpbeam = 10.537477137890088
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4695 - 4695
+gpbeam = 10.537585813851262
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4696 - 4696
+gpbeam = 10.537553090820783
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4697 - 4697
+gpbeam = 10.537738628530718
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4698 - 4698
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4699 - 4699
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4700 - 4700
+gpbeam = 10.53732180657155
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4701 - 4701
+gpbeam = 10.537349854133343
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4702 - 4702
+gpbeam = 10.537702380708094
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4703 - 4703
+gpbeam = 10.53767027388933
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4704 - 4704
+gpbeam = 10.537537685346386
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4705 - 4705
+gpbeam = 10.537478899150383
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4706 - 4706
+gpbeam = 10.53748047586649
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4707 - 4707
+gpbeam = 10.537529832976645
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4708 - 4708
+gpbeam = 10.537318516792247
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4709 - 4709
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4710 - 4710
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4711 - 4711
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4712 - 4712
+gpbeam = 10.537397668662392
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4713 - 4713
+gpbeam = 10.537529824291504
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4714 - 4714
+gpbeam = 10.537602893075869
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4715 - 4715
+gpbeam = 10.537621020535095
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4716 - 4716
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4717 - 4717
+gpbeam = 10.537614579977067
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4718 - 4718
+gpbeam = 10.537600457729392
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4719 - 4719
+gpbeam = 10.53755070228898
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4720 - 4720
+gpbeam = 10.537650671705057
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4721 - 4721
+gpbeam = 10.537587374174123
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4722 - 4722
+gpbeam = 10.537590235644327
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4723 - 4723
+gpbeam = 10.537555800225462
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4724 - 4724
+gpbeam = 10.537443847486482
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4725 - 4725
+gpbeam = 10.537586516222623
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4726 - 4726
+gpbeam = 10.537461939815278
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4727 - 4727
+gpbeam = 10.537376420104584
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4728 - 4728
+gpbeam = 10.537616273786998
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4729 - 4729
+gpbeam = 10.537377733912713
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4730 - 4730
+gpbeam = 10.537370731716413
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4731 - 4731
+gpbeam = 10.537394682997192
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4732 - 4732
+gpbeam = 10.53732744080919
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4733 - 4733
+gpbeam = 10.537505546218952
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4734 - 4734
+gpbeam = 10.53751646425993
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4735 - 4735
+gpbeam = 10.537621021431576
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4736 - 4736
+gpbeam = 10.537603308424577
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4737 - 4737
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4738 - 4738
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4739 - 4739
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4740 - 4740
+gpbeam = 10.53715892283345
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4741 - 4741
+gpbeam = 10.537246991207812
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4742 - 4742
+gpbeam = 10.53750293592415
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4743 - 4743
+gpbeam = 10.537425882026094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4744 - 4744
+gpbeam = 10.537401546141298
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4745 - 4745
+gpbeam = 10.53747115248066
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4746 - 4746
+gpbeam = 10.537428440317562
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4747 - 4747
+gpbeam = 10.537531779006324
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4748 - 4748
+gpbeam = 10.53754568095148
+gtargmass_amu = 12.0107
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4749 - 4749
+gpbeam = 10.53758615733321
+gtargmass_amu = 12.0107
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4750 - 4750
+gpbeam = 10.537588356608271
+gtargmass_amu = 12.0107
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4751 - 4751
+gpbeam = 10.537521959106488
+gtargmass_amu = 12.0107
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4752 - 4752
+gpbeam = 10.537501156025293
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4753 - 4753
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4754 - 4754
+gpbeam = 10.5375116308131
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4755 - 4755
+gpbeam = 10.537523292732907
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4756 - 4756
+gpbeam = 10.53758207215393
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4757 - 4757
+gpbeam = 10.537702380708094
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4758 - 4758
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4759 - 4759
+gpbeam = 10.537146940434408
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4760 - 4760
+gpbeam = 10.537229550605007
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4761 - 4761
+gpbeam = 10.537307419627234
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4762 - 4762
+gpbeam = 10.537211887292042
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4763 - 4763
+gpbeam = 10.53705901493274
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4764 - 4764
+gpbeam = 10.537032546403664
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4765 - 4765
+gpbeam = 10.536848493410343
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4766 - 4766
+gpbeam = 10.536899275599133
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4767 - 4767
+gpbeam = 10.536671490635213
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4768 - 4768
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4769 - 4769
+gpbeam = 10.53673373933557
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4770 - 4770
+gpbeam = 10.537003495426509
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4771 - 4771
+gpbeam = 10.537789265343717
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4772 - 4772
+gpbeam = 10.537370439966784
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4773 - 4773
+gpbeam = 10.537354358349837
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4774 - 4774
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4775 - 4775
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4776 - 4776
+gpbeam = 10.537410798011207
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4777 - 4777
+gpbeam = 10.537346376354842
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4778 - 4778
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4779 - 4779
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4780 - 4780
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4781 - 4781
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4782 - 4782
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4783 - 4783
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4784 - 4784
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4785 - 4785
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+4786 - 4786
+gpbeam = 10.537702380708094
+gtargmass_amu = 0.0
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4787 - 4787
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4788 - 4788
+gpbeam = 10.537828545989347
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4789 - 4789
+gpbeam = 10.537619436352731
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4790 - 4790
+gpbeam = 10.537475617802636
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4791 - 4791
+gpbeam = 10.536902587803702
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4792 - 4792
+gpbeam = 10.53751205197231
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4793 - 4793
+gpbeam = 10.537858168627736
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4794 - 4794
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4795 - 4795
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4796 - 4796
+gpbeam = 10.537652581013154
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4797 - 4797
+gpbeam = 10.537471716637363
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4798 - 4798
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4799 - 4799
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4800 - 4800
+gpbeam = 10.537393009914117
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4801 - 4801
+gpbeam = 10.537153339197115
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4802 - 4802
+gpbeam = 10.5373865876673
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4803 - 4803
+gpbeam = 10.537261421469786
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4804 - 4804
+gpbeam = 10.5372207878575
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4805 - 4805
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4806 - 4806
+gpbeam = 10.537318646181436
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4807 - 4807
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4808 - 4808
+gpbeam = 10.537447855244727
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4809 - 4809
+gpbeam = 10.537511980322591
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4810 - 4810
+gpbeam = 10.537524500629797
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4811 - 4811
+gpbeam = 10.537546182589699
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4812 - 4812
+gpbeam = 10.537524655419375
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4813 - 4813
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.8
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4814 - 4814
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4815 - 4815
+gpbeam = 10.536923195430496
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4816 - 4816
+gpbeam = 10.537622153249231
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4817 - 4817
+gpbeam = 10.537896868904202
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4818 - 4818
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4819 - 4819
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4820 - 4820
+gpbeam = 10.538022653131831
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4821 - 4821
+gpbeam = 10.537628126124822
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4822 - 4822
+gpbeam = 10.537817351130839
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4823 - 4823
+gpbeam = 10.537693425244367
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4824 - 4824
+gpbeam = 10.537650255899425
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4825 - 4825
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4826 - 4826
+gpbeam = 10.53764436743501
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4827 - 4827
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4828 - 4828
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4829 - 4829
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4830 - 4830
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4831 - 4831
+gpbeam = 10.537728205113561
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4832 - 4832
+gpbeam = 10.537538123554603
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4833 - 4833
+gpbeam = 10.537702380708094
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4834 - 4834
+gpbeam = 10.53761318094296
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4835 - 4835
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4836 - 4836
+gpbeam = 10.537688939447342
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4837 - 4837
+gpbeam = 10.537592902038766
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4838 - 4838
+gpbeam = 10.537532017287342
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4839 - 4839
+gpbeam = 10.537601128872709
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4840 - 4840
+gpbeam = 10.537438076158175
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4841 - 4841
+gpbeam = 10.53755896258129
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4842 - 4842
+gpbeam = 10.537484494210375
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4843 - 4843
+gpbeam = 10.53719135839829
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4844 - 4844
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4845 - 4845
+gpbeam = 10.53761044959181
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4846 - 4846
+gpbeam = 10.53744483472603
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4847 - 4847
+gpbeam = 10.537480290968638
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4848 - 4848
+gpbeam = 10.537271813746987
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4849 - 4849
+gpbeam = 10.537467156302142
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4850 - 4850
+gpbeam = 10.537673527226987
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4851 - 4851
+gpbeam = 10.537628852542396
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4852 - 4852
+gpbeam = 10.537619066797815
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4853 - 4853
+gpbeam = 10.53748761855743
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4854 - 4854
+gpbeam = 10.537327299378175
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4855 - 4855
+gpbeam = 10.537308351664203
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4856 - 4856
+gpbeam = 10.537456731581388
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4857 - 4857
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4858 - 4858
+gpbeam = 10.537202178962382
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4859 - 4859
+gpbeam = 10.537483691259977
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4860 - 4860
+gpbeam = 10.537083318702349
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4861 - 4861
+gpbeam = 10.537141075825923
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4862 - 4862
+gpbeam = 10.537154733339094
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4863 - 4863
+gpbeam = 10.537097852074904
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4864 - 4864
+gpbeam = 10.536942192391248
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4865 - 4865
+gpbeam = 10.537128820925433
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4866 - 4866
+gpbeam = 10.537074256198188
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4867 - 4867
+gpbeam = 10.537243012240223
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4868 - 4868
+gpbeam = 10.536965800733709
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4869 - 4869
+gpbeam = 10.537143353470867
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4870 - 4870
+gpbeam = 10.536813192662011
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4871 - 4871
+gpbeam = 10.536909681662413
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4872 - 4872
+gpbeam = 10.537174005887783
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4873 - 4873
+gpbeam = 10.536974534200365
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4874 - 4874
+gpbeam = 10.5371378358362
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4875 - 4875
+gpbeam = 10.537165059661262
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4876 - 4876
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4877 - 4877
+gpbeam = 10.537702380708094
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4878 - 4878
+gpbeam = 10.537024583498685
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4879 - 4879
+gpbeam = 10.537066384335361
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4880 - 4880
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4881 - 4881
+gpbeam = 10.537030187891668
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4882 - 4882
+gpbeam = 10.537236374036127
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4883 - 4883
+gpbeam = 10.537230541018872
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4884 - 4884
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4885 - 4885
+gpbeam = 10.537144738192834
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4886 - 4886
+gpbeam = 10.536696588875882
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4887 - 4887
+gpbeam = 10.537130084135226
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4888 - 4888
+gpbeam = 10.537192742285201
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4889 - 4889
+gpbeam = 10.537213207466817
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4894 - 4894
+gpbeam = 10.537702380708094
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4895 - 4895
+gpbeam = 10.537129118173283
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4896 - 4896
+gpbeam = 10.536504803314907
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4897 - 4897
+gpbeam = 10.537114009801744
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4898 - 4898
+gpbeam = 10.537116068304915
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4899 - 4899
+gpbeam = 10.537122748555644
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4900 - 4900
+gpbeam = 10.537127242509282
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4901 - 4901
+gpbeam = 10.537160410681489
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4902 - 4902
+gpbeam = 10.537063245040807
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4903 - 4903
+gpbeam = 10.537076940635801
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4904 - 4904
+gpbeam = 10.537098768570905
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4905 - 4905
+gpbeam = 10.537029206147013
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4906 - 4906
+gpbeam = 10.537239620143751
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4907 - 4907
+gpbeam = 10.53713845316884
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4908 - 4908
+gpbeam = 10.53714803735817
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4909 - 4909
+gpbeam = 10.537128555692243
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4910 - 4910
+gpbeam = 10.537431467720216
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4911 - 4911
+gpbeam = 10.537168360224701
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4912 - 4912
+gpbeam = 10.537138273140439
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4913 - 4913
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4914 - 4914
+gpbeam = 10.536877430127316
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4915 - 4915
+gpbeam = 10.536881755012597
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4916 - 4916
+gpbeam = 10.536926162751255
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4917 - 4917
+gpbeam = 10.537702380708094
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4918 - 4918
+gpbeam = 10.536856627064253
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4919 - 4919
+gpbeam = 10.53710827946318
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4920 - 4920
+gpbeam = 10.537030899503842
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4921 - 4921
+gpbeam = 10.537158109520464
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4922 - 4922
+gpbeam = 10.537429567910912
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4923 - 4923
+gpbeam = 10.537055336010424
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4924 - 4924
+gpbeam = 10.53729704559378
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4925 - 4925
+gpbeam = 10.537158423487904
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4926 - 4926
+gpbeam = 10.537251796306458
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4927 - 4927
+gpbeam = 10.537169343030737
+gtargmass_amu = 26.981539
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4928 - 4928
+gpbeam = 10.537186954666973
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4929 - 4929
+gpbeam = 10.537264774612229
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4930 - 4930
+gpbeam = 10.537314454343178
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4931 - 4931
+gpbeam = 10.537268662734968
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4932 - 4932
+gpbeam = 10.537131721851189
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4933 - 4933
+gpbeam = 10.537252464444112
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4934 - 4934
+gpbeam = 10.537248842539904
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4935 - 4935
+gpbeam = 10.537151812935742
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4936 - 4936
+gpbeam = 10.537261745361427
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4937 - 4937
+gpbeam = 10.537207774246758
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4938 - 4938
+gpbeam = 10.537237913691959
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4939 - 4939
+gpbeam = 10.537152605004206
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4940 - 4940
+gpbeam = 10.53732703817376
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4941 - 4941
+gpbeam = 10.537176159384456
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4942 - 4942
+gpbeam = 10.537709430292526
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4943 - 4943
+gpbeam = 10.537141755066516
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4944 - 4944
+gpbeam = 10.537235838024747
+gtargmass_amu = 2.014101778
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4945 - 4945
+gpbeam = 10.537255836004217
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4946 - 4946
+gpbeam = 10.537219237666054
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4947 - 4947
+gpbeam = 10.537555970463636
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4948 - 4948
+gpbeam = 10.537324010993315
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4949 - 4949
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4950 - 4950
+gpbeam = 10.537150272409715
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4951 - 4951
+gpbeam = 10.537055903231137
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4952 - 4952
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4953 - 4953
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4954 - 4954
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 2.416
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4955 - 4955
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 4.149
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4956 - 4956
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 4.149
+stheta_lab = 23.79
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4957 - 4957
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 4.149
+stheta_lab = 23.78
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4958 - 4958
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 4.149
+stheta_lab = 23.78
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4960 - 4960
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 4.149
+stheta_lab = 36.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4961 - 4961
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 4.149
+stheta_lab = 37.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4962 - 4962
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -26.86
+hpcentral = 4.149
+stheta_lab = 28.240000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4963 - 4963
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -15.75
+hpcentral = 4.149
+stheta_lab = 27.09
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4964 - 4964
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4965 - 4965
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4966 - 4966
+gpbeam = 10.53744338099043
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4967 - 4967
+gpbeam = 10.537540091472865
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4968 - 4968
+gpbeam = 10.537378515009946
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4969 - 4969
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4970 - 4970
+gpbeam = 10.537660390851155
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4971 - 4971
+gpbeam = 10.537410814986618
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4972 - 4972
+gpbeam = 10.537291925292077
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4973 - 4973
+gpbeam = 10.537376036420323
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4974 - 4974
+gpbeam = 10.537165325387727
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4975 - 4975
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4976 - 4976
+gpbeam = 10.537330644072936
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4977 - 4977
+gpbeam = 10.537174163066242
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4978 - 4978
+gpbeam = 10.537261539161964
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4979 - 4979
+gpbeam = 10.537387679711365
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4980 - 4980
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4981 - 4981
+gpbeam = 10.537166200230772
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4982 - 4982
+gpbeam = 10.537988027216835
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4983 - 4983
+gpbeam = 10.537022729252818
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4984 - 4984
+gpbeam = 10.537709430292526
+gtargmass_amu = 0.0
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4986 - 4986
+gpbeam = 10.537293658998871
+gtargmass_amu = 26.981539
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4987 - 4987
+gpbeam = 10.537709430292526
+gtargmass_amu = 26.981539
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4988 - 4988
+gpbeam = 10.537118915976835
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4989 - 4989
+gpbeam = 10.537195630285083
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4990 - 4990
+gpbeam = 10.537206478135284
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4991 - 4991
+gpbeam = 10.53699874450137
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4992 - 4992
+gpbeam = 10.537118732392184
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4993 - 4993
+gpbeam = 10.537243714323047
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4994 - 4994
+gpbeam = 10.537197505478538
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4995 - 4995
+gpbeam = 10.53735516324468
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4996 - 4996
+gpbeam = 10.537338013789597
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4997 - 4997
+gpbeam = 10.537083476102705
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4998 - 4998
+gpbeam = 10.537174841467717
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+4999 - 4999
+gpbeam = 10.537196891406346
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5000 - 5000
+gpbeam = 10.537167801949723
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5001 - 5001
+gpbeam = 10.537152465021242
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5002 - 5002
+gpbeam = 10.537122651984808
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5003 - 5003
+gpbeam = 10.537200149131957
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5004 - 5004
+gpbeam = 10.53711961296878
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5005 - 5005
+gpbeam = 10.536659548508114
+gtargmass_amu = 0.0
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5006 - 5006
+gpbeam = 10.537075538395012
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5007 - 5007
+gpbeam = 10.537136456487172
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5008 - 5008
+gpbeam = 10.537011717748934
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5009 - 5009
+gpbeam = 10.537372105117747
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5010 - 5010
+gpbeam = 10.537332090215141
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5011 - 5011
+gpbeam = 10.537359856275645
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5012 - 5012
+gpbeam = 10.538084155962093
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5013 - 5013
+gpbeam = 10.537479087919662
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5014 - 5014
+gpbeam = 10.537281469509383
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5015 - 5015
+gpbeam = 10.537176119192724
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5016 - 5016
+gpbeam = 10.537099066522982
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5017 - 5017
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5018 - 5018
+gpbeam = 10.537234385826673
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5019 - 5019
+gpbeam = 10.53731496434436
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5020 - 5020
+gpbeam = 10.537098177215299
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5021 - 5021
+gpbeam = 10.537193751123706
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5022 - 5022
+gpbeam = 10.537749500756055
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5023 - 5023
+gpbeam = 10.537256255505621
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5024 - 5024
+gpbeam = 10.537204200896417
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5025 - 5025
+gpbeam = 10.537709430292526
+gtargmass_amu = 26.981539
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5026 - 5026
+gpbeam = 10.537381341897289
+gtargmass_amu = 26.981539
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5027 - 5027
+gpbeam = 10.537709430292526
+gtargmass_amu = 26.981539
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5028 - 5028
+gpbeam = 10.537217546615874
+gtargmass_amu = 26.981539
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5029 - 5029
+gpbeam = 10.537709430292526
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5030 - 5030
+gpbeam = 10.537293304058068
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5031 - 5031
+gpbeam = 10.537163937538784
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5032 - 5032
+gpbeam = 10.537149504101336
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5033 - 5033
+gpbeam = 10.537163276903595
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5034 - 5034
+gpbeam = 10.537204574458501
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5035 - 5035
+gpbeam = 10.537111309938322
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5036 - 5036
+gpbeam = 10.537109807830186
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5037 - 5037
+gpbeam = 10.537014815438747
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5038 - 5038
+gpbeam = 10.537094104005668
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5039 - 5039
+gpbeam = 10.537330577848678
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5040 - 5040
+gpbeam = 10.537254565317363
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5041 - 5041
+gpbeam = 10.53716954848676
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5042 - 5042
+gpbeam = 10.53738538668569
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5043 - 5043
+gpbeam = 10.53700576883559
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5044 - 5044
+gpbeam = 10.537709430292526
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5045 - 5045
+gpbeam = 10.537709430292526
+gtargmass_amu = 0.0
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5046 - 5046
+gpbeam = 10.537709430292526
+gtargmass_amu = 0.0
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5047 - 5047
+gpbeam = 10.537709430292526
+gtargmass_amu = 0.0
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5048 - 5048
+gpbeam = 10.537709430292526
+gtargmass_amu = 0.0
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5049 - 5049
+gpbeam = 10.537709430292526
+gtargmass_amu = 0.0
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5050 - 5050
+gpbeam = 10.537709430292526
+gtargmass_amu = 0.0
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5051 - 5051
+gpbeam = 10.537709430292526
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5052 - 5052
+gpbeam = 10.537709430292526
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5053 - 5053
+gpbeam = 10.537234598091118
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5054 - 5054
+gpbeam = 10.53721743257632
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5055 - 5055
+gpbeam = 10.537124335874008
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5056 - 5056
+gpbeam = 10.53776084907177
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5057 - 5057
+gpbeam = 10.539090126709885
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5058 - 5058
+gpbeam = 10.537709430292526
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5059 - 5059
+gpbeam = 10.53820607559744
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5060 - 5060
+gpbeam = 10.537106398091051
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5061 - 5061
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5062 - 5062
+gpbeam = 10.53750818950175
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5063 - 5063
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5064 - 5064
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5065 - 5065
+gpbeam = 10.537163413005427
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5066 - 5066
+gpbeam = 10.537357368312367
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5067 - 5067
+gpbeam = 10.537356428990947
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5068 - 5068
+gpbeam = 10.539846913922817
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5069 - 5069
+gpbeam = 10.53790376132783
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5070 - 5070
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5071 - 5071
+gpbeam = 10.538394418961548
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5072 - 5072
+gpbeam = 10.536546253925145
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5073 - 5073
+gpbeam = 10.536333440266755
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5075 - 5075
+gpbeam = 10.536787170813323
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5076 - 5076
+gpbeam = 10.536629493195196
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5077 - 5077
+gpbeam = 10.538081438706898
+gtargmass_amu = 26.981539
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5078 - 5078
+gpbeam = 10.537214632222557
+gtargmass_amu = 26.981539
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5079 - 5079
+gpbeam = 10.537199858517381
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5080 - 5080
+gpbeam = 10.5372728090557
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5081 - 5081
+gpbeam = 10.537096784730743
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5082 - 5082
+gpbeam = 10.53719145134881
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5083 - 5083
+gpbeam = 10.537074762856902
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5084 - 5084
+gpbeam = 10.5371537746697
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5085 - 5085
+gpbeam = 10.537184711019055
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5086 - 5086
+gpbeam = 10.536868817566404
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5087 - 5087
+gpbeam = 10.53718680209456
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5088 - 5088
+gpbeam = 10.537329532452079
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5089 - 5089
+gpbeam = 10.53717236129663
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5090 - 5090
+gpbeam = 10.537045225931855
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5091 - 5091
+gpbeam = 10.537266226787885
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5092 - 5092
+gpbeam = 10.537200115602374
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5093 - 5093
+gpbeam = 10.537136996308407
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5094 - 5094
+gpbeam = 10.537219726017216
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5095 - 5095
+gpbeam = 10.537250883382844
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5096 - 5096
+gpbeam = 10.537133288325629
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5097 - 5097
+gpbeam = 10.536952900632707
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5098 - 5098
+gpbeam = 10.537147674595488
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5099 - 5099
+gpbeam = 10.537099332630625
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5100 - 5100
+gpbeam = 10.537134608690671
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5101 - 5101
+gpbeam = 10.537093919400391
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5102 - 5102
+gpbeam = 10.53799627946929
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5103 - 5103
+gpbeam = 10.537163507929884
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5104 - 5104
+gpbeam = 10.537147025594502
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5105 - 5105
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5106 - 5106
+gpbeam = 10.537334928365468
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5107 - 5107
+gpbeam = 10.53701457297294
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5108 - 5108
+gpbeam = 10.537208916375466
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5109 - 5109
+gpbeam = 10.537240807554584
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5110 - 5110
+gpbeam = 10.536990911231257
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5111 - 5111
+gpbeam = 10.53727105283271
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5112 - 5112
+gpbeam = 10.537230136305332
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5113 - 5113
+gpbeam = 10.537223361288834
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5114 - 5114
+gpbeam = 10.537953948665063
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5115 - 5115
+gpbeam = 10.537952156136091
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5116 - 5116
+gpbeam = 10.537866577894283
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5117 - 5117
+gpbeam = 10.537876567770105
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5118 - 5118
+gpbeam = 10.537901724667403
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5119 - 5119
+gpbeam = 10.537709430292526
+gtargmass_amu = 26.981539
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5120 - 5120
+gpbeam = 10.537164218930377
+gtargmass_amu = 26.981539
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5121 - 5121
+gpbeam = 10.53712580616298
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5122 - 5122
+gpbeam = 10.537279309061223
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5123 - 5123
+gpbeam = 10.53695896876555
+gtargmass_amu = 0.0
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5124 - 5124
+gpbeam = 10.536739155646952
+gtargmass_amu = 0.0
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5125 - 5125
+gpbeam = 10.536658745639123
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5126 - 5126
+gpbeam = 10.536949035525552
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5127 - 5127
+gpbeam = 10.53683143044376
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5128 - 5128
+gpbeam = 10.537084163960213
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5129 - 5129
+gpbeam = 10.537159845831344
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5130 - 5130
+gpbeam = 10.537451783293648
+gtargmass_amu = 0.0
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5131 - 5131
+gpbeam = 10.538389173887314
+gtargmass_amu = 0.0
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5132 - 5132
+gpbeam = 10.537511961323208
+gtargmass_amu = 0.0
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5133 - 5133
+gpbeam = 10.537612699163375
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5134 - 5134
+gpbeam = 10.537709430292526
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5135 - 5135
+gpbeam = 10.537214716473589
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5136 - 5136
+gpbeam = 10.537159818717015
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5137 - 5137
+gpbeam = 10.537229882283336
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5138 - 5138
+gpbeam = 10.537138932303398
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5139 - 5139
+gpbeam = 10.537308910273905
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5140 - 5140
+gpbeam = 10.537241497930612
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5141 - 5141
+gpbeam = 10.537328365112272
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5142 - 5142
+gpbeam = 10.53705158284211
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5143 - 5143
+gpbeam = 10.53707376580773
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5144 - 5144
+gpbeam = 10.537229686019442
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5145 - 5145
+gpbeam = 10.537099798960497
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5146 - 5146
+gpbeam = 10.537960648151659
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5147 - 5147
+gpbeam = 10.53721382040079
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5148 - 5148
+gpbeam = 10.537112176221067
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5149 - 5149
+gpbeam = 10.537046802549481
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5150 - 5150
+gpbeam = 10.53797917505463
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5151 - 5151
+gpbeam = 10.537601845098433
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5152 - 5152
+gpbeam = 10.53717547938868
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5153 - 5153
+gpbeam = 10.537060210626091
+gtargmass_amu = 2.014101778
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5154 - 5154
+gpbeam = 10.538096213006659
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5155 - 5155
+gpbeam = 10.537190211451284
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5156 - 5156
+gpbeam = 10.537231945547326
+gtargmass_amu = 12.0107
+htheta_lab = -15.195
+hpcentral = 6.667
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5157 - 5157
+gpbeam = 10.537709430292526
+gtargmass_amu = 12.0107
+htheta_lab = -15.195
+hpcentral = 6.667
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5158 - 5158
+gpbeam = 10.53634338335563
+gtargmass_amu = 12.0107
+htheta_lab = -15.195
+hpcentral = 6.667
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5159 - 5159
+gpbeam = 10.536153537285529
+gtargmass_amu = 12.0107
+htheta_lab = -15.195
+hpcentral = 6.667
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5160 - 5160
+gpbeam = 10.53636954739391
+gtargmass_amu = 12.0107
+htheta_lab = -15.195
+hpcentral = 6.667
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5161 - 5161
+gpbeam = 10.537265784438182
+gtargmass_amu = 12.0107
+htheta_lab = -15.195
+hpcentral = 6.667
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5162 - 5162
+gpbeam = 10.537709430292526
+gtargmass_amu = 12.0107
+htheta_lab = -15.195
+hpcentral = 6.667
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5163 - 5163
+gpbeam = 10.537286018549425
+gtargmass_amu = 12.0107
+htheta_lab = -15.195
+hpcentral = 6.667
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5164 - 5164
+gpbeam = 10.53725756403175
+gtargmass_amu = 12.0107
+htheta_lab = -15.195
+hpcentral = 6.667
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5165 - 5165
+gpbeam = 10.53732235070621
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 6.117
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5166 - 5166
+gpbeam = 10.537280811089603
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 6.117
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5167 - 5167
+gpbeam = 10.537496800340437
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 6.117
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5168 - 5168
+gpbeam = 10.53724553428062
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 5.878
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5169 - 5169
+gpbeam = 10.53730655583949
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 5.878
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5170 - 5170
+gpbeam = 10.53730655583949
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 5.878
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5171 - 5171
+gpbeam = 10.53730655583949
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 5.878
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5172 - 5172
+gpbeam = 10.53730655583949
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 5.639
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5173 - 5173
+gpbeam = 10.53730655583949
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 5.639
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5174 - 5174
+gpbeam = 10.53730655583949
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 5.639
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5175 - 5175
+gpbeam = 10.53730655583949
+gtargmass_amu = 12.0107
+htheta_lab = -15.200000000000001
+hpcentral = 5.639
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5176 - 5176
+gpbeam = 10.537190211451284
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5177 - 5177
+gpbeam = 10.537190211451284
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5178 - 5178
+gpbeam = 10.537190211451284
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5179 - 5179
+gpbeam = 10.537190211451284
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5180 - 5180
+gpbeam = 10.537190211451284
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5181 - 5181
+gpbeam = 10.537190211451284
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5182 - 5182
+gpbeam = 10.537190211451284
+gtargmass_amu = 1.007825032
+htheta_lab = -15.200000000000001
+hpcentral = 4.149
+stheta_lab = 27.5
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5183 - 5183
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 31.87
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5184 - 5184
+gpbeam = 10.53738292798754
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 31.87
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5185 - 5185
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 33.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5186 - 5186
+gpbeam = 10.537300197234396
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 33.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5187 - 5187
+gpbeam = 10.537542267736326
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 34.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5188 - 5188
+gpbeam = 10.537102670194697
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 34.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5189 - 5189
+gpbeam = 10.537214780027778
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5190 - 5190
+gpbeam = 10.537238535887969
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5191 - 5191
+gpbeam = 10.537387455358296
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 33.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5192 - 5192
+gpbeam = 10.537180099408355
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 33.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5193 - 5193
+gpbeam = 10.53716904971232
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 33.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5194 - 5194
+gpbeam = 10.537122558318158
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 34.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5195 - 5195
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 34.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5196 - 5196
+gpbeam = 10.53714622061689
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5197 - 5197
+gpbeam = 10.537080773663078
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5198 - 5198
+gpbeam = 10.537319964388294
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 33.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5199 - 5199
+gpbeam = 10.537316061541238
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 33.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5200 - 5200
+gpbeam = 10.537340378281355
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 34.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5201 - 5201
+gpbeam = 10.537129803794336
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 34.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5202 - 5202
+gpbeam = 10.537254521221707
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5203 - 5203
+gpbeam = 10.536536981011615
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5204 - 5204
+gpbeam = 10.536806055737905
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 33.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5205 - 5205
+gpbeam = 10.537282619875333
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 33.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5206 - 5206
+gpbeam = 10.536591722221297
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 34.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5207 - 5207
+gpbeam = 10.536468816116427
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 34.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5208 - 5208
+gpbeam = 10.536537590069996
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5209 - 5209
+gpbeam = 10.537709430292526
+gtargmass_amu = 1.007825032
+htheta_lab = -28.67
+hpcentral = 4.31
+stheta_lab = 31.85
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5210 - 5210
+gpbeam = 6.367806873325798
+gtargmass_amu = 0.0
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 34.86
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5211 - 5211
+gpbeam = 6.368261964611038
+gtargmass_amu = 12.0107
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 34.86
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5212 - 5212
+gpbeam = 6.367806873325798
+gtargmass_amu = 12.0107
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 34.86
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5213 - 5213
+gpbeam = 6.367806873325798
+gtargmass_amu = 12.0107
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 34.86
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5214 - 5214
+gpbeam = 6.36837296839418
+gtargmass_amu = 12.0107
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 34.86
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5215 - 5215
+gpbeam = 6.368387175443503
+gtargmass_amu = 12.0107
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 34.86
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5216 - 5216
+gpbeam = 6.368172727781776
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 34.86
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5217 - 5217
+gpbeam = 6.368191541565044
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 34.86
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5218 - 5218
+gpbeam = 6.367806873325798
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 34.86
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5219 - 5219
+gpbeam = 6.368382183107733
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 34.86
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5220 - 5220
+gpbeam = 6.367806873325798
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 36.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5221 - 5221
+gpbeam = 6.368421447146419
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 36.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5222 - 5222
+gpbeam = 6.367806873325798
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 37.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5223 - 5223
+gpbeam = 6.368363786270486
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 37.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5224 - 5224
+gpbeam = 6.367806873325798
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 37.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5225 - 5225
+gpbeam = 6.368464494419217
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 37.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5226 - 5226
+gpbeam = 6.367806873325798
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 34.87
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5227 - 5227
+gpbeam = 6.36842553633414
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 34.87
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5228 - 5228
+gpbeam = 6.368521202301115
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 36.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5229 - 5229
+gpbeam = 6.368535575704147
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 36.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5230 - 5230
+gpbeam = 6.368517122163032
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 36.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5231 - 5231
+gpbeam = 6.368425222843131
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 37.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5232 - 5232
+gpbeam = 6.368552377535408
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 37.47
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5233 - 5233
+gpbeam = 6.368564454765528
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 34.87
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5234 - 5234
+gpbeam = 6.368556857663416
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 34.87
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5235 - 5235
+gpbeam = 6.368533525742274
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 36.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5236 - 5236
+gpbeam = 6.3679503671060695
+gtargmass_amu = 1.007825032
+htheta_lab = -35.96
+hpcentral = 2.639
+stheta_lab = 36.17
+nps_theta_offset= -16.3
+hpartmass = 0.938272
+
+5237 - 5237
+gpbeam = 6.367803265520971
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5238 - 5238
+gpbeam = 6.3691120460246236
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5239 - 5239
+gpbeam = 6.36796098942005
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5240 - 5240
+gpbeam = 6.367920877759213
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5241 - 5241
+gpbeam = 6.368079329391341
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5242 - 5242
+gpbeam = 6.367943891094306
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5243 - 5243
+gpbeam = 6.367935971381265
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5244 - 5244
+gpbeam = 6.367981070085821
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5245 - 5245
+gpbeam = 6.368027085511163
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5246 - 5246
+gpbeam = 6.369348924009455
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5247 - 5247
+gpbeam = 6.368052262258928
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5248 - 5248
+gpbeam = 6.367802769758689
+gtargmass_amu = 26.981539
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5249 - 5249
+gpbeam = 6.369028767806307
+gtargmass_amu = 26.981539
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5250 - 5250
+gpbeam = 6.368146567581424
+gtargmass_amu = 26.981539
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5251 - 5251
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5252 - 5252
+gpbeam = 6.369079537722747
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5253 - 5253
+gpbeam = 6.369993025111636
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5254 - 5254
+gpbeam = 6.367887658656747
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5255 - 5255
+gpbeam = 6.36802957266132
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5256 - 5256
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5257 - 5257
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5258 - 5258
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5259 - 5259
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5260 - 5260
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5261 - 5261
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5262 - 5262
+gpbeam = 6.369461662080841
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5263 - 5263
+gpbeam = 6.369242096617514
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5264 - 5264
+gpbeam = 6.369601885889479
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5265 - 5265
+gpbeam = 6.369261006584638
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5266 - 5266
+gpbeam = 6.369025455855401
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5267 - 5267
+gpbeam = 6.369150202114881
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5268 - 5268
+gpbeam = 6.369329705838812
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5269 - 5269
+gpbeam = 6.3691618846760205
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5270 - 5270
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5271 - 5271
+gpbeam = 6.369399080132868
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5272 - 5272
+gpbeam = 6.369359861497505
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5273 - 5273
+gpbeam = 6.369087332081441
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5274 - 5274
+gpbeam = 6.369222048837384
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5275 - 5275
+gpbeam = 6.369431242796416
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5276 - 5276
+gpbeam = 6.369398528621603
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5277 - 5277
+gpbeam = 6.369401715907723
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5278 - 5278
+gpbeam = 6.367918527633831
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5279 - 5279
+gpbeam = 6.3679424938970435
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5280 - 5280
+gpbeam = 6.367563035667132
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5281 - 5281
+gpbeam = 6.367802769758689
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5282 - 5282
+gpbeam = 6.367923299983159
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5283 - 5283
+gpbeam = 6.367969841562894
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5284 - 5284
+gpbeam = 6.367897244119601
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5285 - 5285
+gpbeam = 6.367988125056383
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5286 - 5286
+gpbeam = 6.368064243858738
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5287 - 5287
+gpbeam = 6.36808572008475
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5288 - 5288
+gpbeam = 6.367966029141712
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5289 - 5289
+gpbeam = 6.369201948221185
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5291 - 5291
+gpbeam = 6.3680638742287465
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5292 - 5292
+gpbeam = 6.367967087835636
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5293 - 5293
+gpbeam = 6.367802769758689
+gtargmass_amu = 0.0
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5294 - 5294
+gpbeam = 6.368059137387829
+gtargmass_amu = 26.981539
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5295 - 5295
+gpbeam = 6.368101069728715
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5296 - 5296
+gpbeam = 6.368104499552852
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5297 - 5297
+gpbeam = 6.368149668887015
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5298 - 5298
+gpbeam = 6.368158176505515
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5299 - 5299
+gpbeam = 6.368094059544369
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5300 - 5300
+gpbeam = 6.368111815921987
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5301 - 5301
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5302 - 5302
+gpbeam = 6.368102312832555
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5303 - 5303
+gpbeam = 6.36820760716141
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5304 - 5304
+gpbeam = 6.368051584477122
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5305 - 5305
+gpbeam = 6.368062855197285
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5306 - 5306
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5307 - 5307
+gpbeam = 6.368094650068639
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5308 - 5308
+gpbeam = 6.368093162295782
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5309 - 5309
+gpbeam = 6.368131741566037
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5310 - 5310
+gpbeam = 6.368169475090676
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5311 - 5311
+gpbeam = 6.3681695625223975
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5312 - 5312
+gpbeam = 6.368237566026161
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5313 - 5313
+gpbeam = 6.367935621567381
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5314 - 5314
+gpbeam = 6.36784447089263
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5315 - 5315
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5316 - 5316
+gpbeam = 6.3681017505750415
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5317 - 5317
+gpbeam = 6.368226488325677
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5318 - 5318
+gpbeam = 6.367906203464906
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5319 - 5319
+gpbeam = 6.36787079657915
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5320 - 5320
+gpbeam = 6.368096123113789
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5321 - 5321
+gpbeam = 6.367819213524907
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5322 - 5322
+gpbeam = 6.367947853676879
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5323 - 5323
+gpbeam = 6.3680297649689654
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5324 - 5324
+gpbeam = 6.367994565365922
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5325 - 5325
+gpbeam = 6.3679185980311255
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5326 - 5326
+gpbeam = 6.368154453774502
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5327 - 5327
+gpbeam = 6.3680333006905725
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5328 - 5328
+gpbeam = 6.368009003051992
+gtargmass_amu = 26.981539
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5329 - 5329
+gpbeam = 6.368071971654917
+gtargmass_amu = 26.981539
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5330 - 5330
+gpbeam = 6.367906729885678
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5331 - 5331
+gpbeam = 6.368013243651474
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5332 - 5332
+gpbeam = 6.368024243848554
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5333 - 5333
+gpbeam = 6.368090094834373
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5334 - 5334
+gpbeam = 6.36804874679131
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5335 - 5335
+gpbeam = 6.367969477239943
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5336 - 5336
+gpbeam = 6.368056092254483
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5337 - 5337
+gpbeam = 6.367987958604273
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5338 - 5338
+gpbeam = 6.368007797114646
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5339 - 5339
+gpbeam = 6.367950345839816
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5340 - 5340
+gpbeam = 6.367996077020778
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5341 - 5341
+gpbeam = 6.368083491445385
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5342 - 5342
+gpbeam = 6.36799141198443
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5343 - 5343
+gpbeam = 6.3680214200787955
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5344 - 5344
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5345 - 5345
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5346 - 5346
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5347 - 5347
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5348 - 5348
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5349 - 5349
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5350 - 5350
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5351 - 5351
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5352 - 5352
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5353 - 5353
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.310000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5354 - 5354
+gpbeam = 6.367802769758689
+gtargmass_amu = 0.0
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5355 - 5355
+gpbeam = 6.369264927454472
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5356 - 5356
+gpbeam = 6.369138375598157
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5357 - 5357
+gpbeam = 6.369156036118372
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5358 - 5358
+gpbeam = 6.36910105307012
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5359 - 5359
+gpbeam = 6.369307025574419
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5360 - 5360
+gpbeam = 6.367802769758689
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5361 - 5361
+gpbeam = 6.369222944990589
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5362 - 5362
+gpbeam = 6.369301327079509
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5363 - 5363
+gpbeam = 6.369284879187348
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5364 - 5364
+gpbeam = 6.369536340321557
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5365 - 5365
+gpbeam = 6.369430092526136
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5366 - 5366
+gpbeam = 6.369302400388611
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5367 - 5367
+gpbeam = 6.369396596209167
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5368 - 5368
+gpbeam = 6.369460900682082
+gtargmass_amu = 26.981539
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5369 - 5369
+gpbeam = 6.369619420833979
+gtargmass_amu = 26.981539
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5370 - 5370
+gpbeam = 6.3696352079983125
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5371 - 5371
+gpbeam = 6.36936541785633
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5372 - 5372
+gpbeam = 6.369551173727671
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5373 - 5373
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5374 - 5374
+gpbeam = 6.369460711551144
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5375 - 5375
+gpbeam = 6.369487637965591
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5376 - 5376
+gpbeam = 6.369485072569078
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5377 - 5377
+gpbeam = 6.369687407642785
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5378 - 5378
+gpbeam = 6.369199712669111
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5379 - 5379
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5380 - 5380
+gpbeam = 6.3692226139138075
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5381 - 5381
+gpbeam = 6.369187679814688
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5382 - 5382
+gpbeam = 6.369143198629352
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5383 - 5383
+gpbeam = 6.369287364148467
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 33.92
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5384 - 5384
+gpbeam = 6.369320849164274
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5385 - 5385
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5386 - 5386
+gpbeam = 6.369314480894042
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5387 - 5387
+gpbeam = 6.369497893274036
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5388 - 5388
+gpbeam = 6.369396124721738
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5389 - 5389
+gpbeam = 6.369326012739111
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5390 - 5390
+gpbeam = 6.3692512322346575
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5391 - 5391
+gpbeam = 6.369352489379108
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5392 - 5392
+gpbeam = 6.367802769758689
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5393 - 5393
+gpbeam = 6.369404638495373
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5394 - 5394
+gpbeam = 6.369338601536217
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5395 - 5395
+gpbeam = 6.369252808154199
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5396 - 5396
+gpbeam = 6.368089504888048
+gtargmass_amu = 26.981539
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5397 - 5397
+gpbeam = 6.36921938645858
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5398 - 5398
+gpbeam = 6.369350947507815
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5399 - 5399
+gpbeam = 6.369345111733693
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5400 - 5400
+gpbeam = 6.369211016830678
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5401 - 5401
+gpbeam = 6.369241053670053
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5402 - 5402
+gpbeam = 6.369447373896394
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5403 - 5403
+gpbeam = 6.3692158290093746
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5404 - 5404
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5405 - 5405
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5406 - 5406
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5407 - 5407
+gpbeam = 6.369443451454585
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5408 - 5408
+gpbeam = 6.367846391248015
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5409 - 5409
+gpbeam = 6.367832220763239
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5410 - 5410
+gpbeam = 6.367854583611044
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5411 - 5411
+gpbeam = 6.367881337124739
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5412 - 5412
+gpbeam = 6.36785835626059
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5413 - 5413
+gpbeam = 6.367888086272004
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5414 - 5414
+gpbeam = 6.36787189111611
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5415 - 5415
+gpbeam = 6.367829294906488
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5416 - 5416
+gpbeam = 6.367854242159195
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5417 - 5417
+gpbeam = 6.367833324811121
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5418 - 5418
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5419 - 5419
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5420 - 5420
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5421 - 5421
+gpbeam = 6.367877528339032
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5422 - 5422
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.3
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5423 - 5423
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5424 - 5424
+gpbeam = 6.368103930236737
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5425 - 5425
+gpbeam = 6.367852501606352
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5426 - 5426
+gpbeam = 6.367802769758689
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5427 - 5427
+gpbeam = 6.367931726372751
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5428 - 5428
+gpbeam = 6.3678586469604745
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5429 - 5429
+gpbeam = 6.367868549904634
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5430 - 5430
+gpbeam = 6.367924751068063
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5431 - 5431
+gpbeam = 6.3678416212540085
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5432 - 5432
+gpbeam = 6.367871815996499
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5433 - 5433
+gpbeam = 6.367877638795158
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5434 - 5434
+gpbeam = 6.367760197653866
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5435 - 5435
+gpbeam = 6.36788086596316
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5436 - 5436
+gpbeam = 6.367885785149022
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5437 - 5437
+gpbeam = 6.3686177875867775
+gtargmass_amu = 26.981539
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5438 - 5438
+gpbeam = 6.367870725640746
+gtargmass_amu = 26.981539
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5439 - 5439
+gpbeam = 6.3678605804804125
+gtargmass_amu = 26.981539
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5440 - 5440
+gpbeam = 6.366562996244891
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5441 - 5441
+gpbeam = 6.3678324806945135
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5442 - 5442
+gpbeam = 6.3677505997607735
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5443 - 5443
+gpbeam = 6.36786070430481
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5444 - 5444
+gpbeam = 6.3677908410773725
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5445 - 5445
+gpbeam = 6.367861071804988
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5446 - 5446
+gpbeam = 6.36785609515905
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5447 - 5447
+gpbeam = 6.367821306101508
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.71
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5448 - 5448
+gpbeam = 6.36795252592496
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.78
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5449 - 5449
+gpbeam = 6.367887337990861
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.78
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5450 - 5450
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.78
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5451 - 5451
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.78
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5452 - 5452
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 30.78
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5453 - 5453
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 31.400000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5454 - 5454
+gpbeam = 6.367959113109279
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 31.400000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5455 - 5455
+gpbeam = 6.367838584527031
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 31.400000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5456 - 5456
+gpbeam = 6.367811409051993
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 31.400000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5457 - 5457
+gpbeam = 6.367820996183596
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 31.400000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5458 - 5458
+gpbeam = 6.367802769758689
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 31.400000000000002
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5459 - 5459
+gpbeam = 6.3678636764922265
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 31.98
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5460 - 5460
+gpbeam = 6.367810336909555
+gtargmass_amu = 2.014101778
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 31.98
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5461 - 5461
+gpbeam = 6.367781311026706
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 31.98
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5462 - 5462
+gpbeam = 6.367848298929436
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 31.98
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+
+5463 - 5463
+gpbeam = 6.367800050372158
+gtargmass_amu = 1.007825032
+htheta_lab = -25.93
+hpcentral = 2.638
+stheta_lab = 32.01
+nps_theta_offset= -16.3
+hpartmass = 0.000511
+


### PR DESCRIPTION
…all optics and 6.667 GeV/c optics in March